### PR TITLE
Plug-in interface

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Neo4j::Driver
 
+0.3050  2022-05-31
+
+ - Replace experimental net_module config option by plug-in interface
+
 0.30  2022-05-20
 
  - Add experimental config option concurrent_tx to explicitly enable support

--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Neo4j::Driver
 
-0.3055  2022-06-09
+0.3056  2022-06-09
 
  - Replace experimental net_module config option by plug-in interface
 

--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Neo4j::Driver
 
-0.3052  2022-06-03
+0.3053  2022-06-03
 
  - Replace experimental net_module config option by plug-in interface
 

--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Neo4j::Driver
 
-0.3050  2022-05-31
+0.3052  2022-06-03
 
  - Replace experimental net_module config option by plug-in interface
 

--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 Revision history for Neo4j::Driver
 
-0.3053  2022-06-03
+0.3055  2022-06-09
 
  - Replace experimental net_module config option by plug-in interface
 

--- a/TODO.pod
+++ b/TODO.pod
@@ -45,9 +45,6 @@ later expansion).
 
 =item * L<Neo4j::Driver/"Parameter syntax conversion">: make stable
 
-=item * L<Neo4j::Driver/"Custom networking modules">: make stable, but
-not until at least part of the C<result_handlers> API has been specified
-
 =item * L<Neo4j::Driver::Result/"Look ahead in the result stream">:
 make C<peek()> stable once C<fetch()> reliably buffers two records
 
@@ -115,10 +112,10 @@ L<majensen/libneo4j-client#8|https://github.com/majensen/libneo4j-client/commit/
 allowing for indexing by search engines.
 
 =item * We need complete working code examples, such as that Neo4j movies app.
-Some of the deprecated functionality could also be implemented as a custom
-module named S<e. g.> Neo4j::Driver::Net::HTTP::Extra. Such a module might
+Some of the deprecated functionality could also be implemented as plug-ins
+in a dist named S<e. g.> Neo4j::Driver::Net::HTTP::Extra. Such a plug-in might
 be directly useful to some users, but most importantly, it would serve to
-demonstrate some of the net_module functionality and how that can be used.
+demonstrate some of the plug-in API's functionality and how that can be used.
 
 =back
 
@@ -271,30 +268,10 @@ L<Neo4j::Bolt> 0.4201 according to the docs; need to check source.
 
 =over
 
-=item * The lingo for the different components is not very clear. Options
-to be considered:
-
-=over
-
-=item Should "net helper" be renamed to "net controller"?
-
-=item Should "net module" be renamed to "net agent"?
-
-Problem is, "agent" is already an overloaded term.
-
-=item Should "net module" be renamed to "net plugin"?
-
-The primary problem would seem to be that usually zero or multiple plugins
-are supported, but we require exactly one plugin here. Also, currently we
-I<include> a net module with the distribution, so that's not really a plugin;
-however, we could probably just describe that as the "default plugin".
-
-=back
-
-=item * As a micro-optimisation for the HTTP net_module API, it could be
+=item * As a micro-optimisation for the HTTP net adapter API, it could be
 guaranteed for the C<http_header()> method that the returned hashref will not
 be used by the driver/controller after the next call to C<request()>, so that
-the underlying hash may be reused by the net module.
+the underlying hash may be reused by the net adapter.
 
 =back
 

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2016-2022
 
-version = 0.3053
+version = 0.3055
 release_status = stable
 
 ; The reason for using AutoPrereqs with a great many exceptions

--- a/dist.ini
+++ b/dist.ini
@@ -16,7 +16,7 @@ release_status = stable
 ; don't mention modules that have been in core since the minimum supported Perl version
 skip = ^lib|overload|strict|utf8|warnings$
 skip = ^Carp|Scalar::Util$
-skip = ^Digest::MD5|File::Basename$
+skip = ^(Digest::MD5|Exporter|File::Basename)$
 ; URI::_server is part of URI, which is included by AutoPrereqs
 skip = ^URI::_server$
 ; Bolt is an XS module and loaded dynamically only if available

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2016-2022
 
-version = 0.3050
+version = 0.3052
 release_status = stable
 
 ; The reason for using AutoPrereqs with a great many exceptions

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2016-2022
 
-version = 0.30
+version = 0.3050
 release_status = stable
 
 ; The reason for using AutoPrereqs with a great many exceptions
@@ -82,6 +82,7 @@ finder = PodWeaverFiles
 finder = :InstallModules
 skip = TODO.pod$
 skip = Net/(?:Bolt|HTTP)\.pm$
+skip = PluginManager.pm$
 skip = ResultColumns.pm$
 
 [PodSyntaxTests]

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2016-2022
 
-version = 0.3055
+version = 0.3056
 release_status = stable
 
 ; The reason for using AutoPrereqs with a great many exceptions

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2016-2022
 
-version = 0.3052
+version = 0.3053
 release_status = stable
 
 ; The reason for using AutoPrereqs with a great many exceptions

--- a/lib/Neo4j/Driver.pm
+++ b/lib/Neo4j/Driver.pm
@@ -408,6 +408,21 @@ option that allows specifying multiple plugins instead of just a
 single module. Existing networking modules will work as plugins
 with only minimal changes.
 
+=head2 Plug-in modules
+
+ $driver->plugin('Local::MyPlugin');
+
+The driver offers a simple plug-in interface. Plug-ins are modules
+providing handlers for events that may be triggered by the driver.
+Plug-ins are loaded by calling the C<plugin()> method with the
+module name as parameter. Your code must C<use> or C<require> the
+module it specifies here.
+
+B<Note: The plug-in API is currently unimplemented.>
+
+Details on the implementation of plug-ins including descriptions of
+individual events are provided in L<Neo4j::Driver::Plugins>.
+
 =head2 Concurrent transactions in HTTP sessions
 
  $session = Neo4j::Driver->new({

--- a/lib/Neo4j/Driver.pm
+++ b/lib/Neo4j/Driver.pm
@@ -412,12 +412,9 @@ auto-detection.
  $driver->config(net_module => '');     # use the built-in modules
 
 This config option is experimental because the API for custom
-networking modules is still evolving. See L<Neo4j::Driver::Net>
-for details.
-
-It is likely that this option will soon be replaced with a new
-option that allows specifying multiple plugins instead of just a
-single module. Existing networking modules will work as plugins
+networking modules is in the process of being replaced by
+L<Neo4j::Driver::Plugin/"http_adapter_factory">.
+Existing networking modules will work as plugins
 with only minimal changes.
 
 =head2 Plug-in modules

--- a/lib/Neo4j/Driver.pm
+++ b/lib/Neo4j/Driver.pm
@@ -185,8 +185,9 @@ sub _parse_options {
 
 sub plugin {
 	# uncoverable pod (experimental feature)
-	my ($self, $package) = @_;
+	my ($self, $package, @extra) = @_;
 	
+	croak "plugin() with more than one argument is unsupported" if @extra;
 	$self->{plugins}->_register_plugin($package);
 	return $self;
 }
@@ -421,13 +422,15 @@ with only minimal changes.
 
 =head2 Plug-in modules
 
- $driver->plugin('Local::MyPlugin');
+ $driver->plugin( 'Local::MyPlugin' );
+ $driver->plugin(  Local::MyPlugin->new );
 
 The driver offers a simple plug-in interface. Plug-ins are modules
 providing handlers for events that may be triggered by the driver.
 Plug-ins are loaded by calling the C<plugin()> method with the
 module name as parameter. Your code must C<use> or C<require> the
-module it specifies here.
+module it specifies here. Alternatively, the blessed instance of
+a plug-in may be given.
 
 B<Warning: The entire plug-in API is currently highly experimental.>
 

--- a/lib/Neo4j/Driver.pm
+++ b/lib/Neo4j/Driver.pm
@@ -10,6 +10,7 @@ package Neo4j::Driver;
 use Carp qw(croak);
 
 use URI 1.25;
+use Neo4j::Driver::PluginManager;
 use Neo4j::Driver::Session;
 
 use Neo4j::Driver::Type::Node;
@@ -58,6 +59,7 @@ sub new {
 	my ($class, $config, @extra) = @_;
 	
 	my $self = bless { %DEFAULTS }, $class;
+	$self->{plugins} = Neo4j::Driver::PluginManager->new;
 	
 	croak __PACKAGE__ . "->new() with multiple arguments unsupported" if @extra;
 	$config = { uri => $config } if ref $config ne 'HASH';
@@ -178,6 +180,15 @@ sub _parse_options {
 	croak "Unsupported $context option: " . join ", ", sort @unsupported if @unsupported;
 	
 	return %options;
+}
+
+
+sub plugin {
+	# uncoverable pod (experimental feature)
+	my ($self, $package) = @_;
+	
+	$self->{plugins}->_register_plugin($package);
+	return $self;
 }
 
 
@@ -418,7 +429,7 @@ Plug-ins are loaded by calling the C<plugin()> method with the
 module name as parameter. Your code must C<use> or C<require> the
 module it specifies here.
 
-B<Note: The plug-in API is currently unimplemented.>
+B<Warning: The entire plug-in API is currently highly experimental.>
 
 Details on the implementation of plug-ins including descriptions of
 individual events are provided in L<Neo4j::Driver::Plugins>.

--- a/lib/Neo4j/Driver.pm
+++ b/lib/Neo4j/Driver.pm
@@ -399,10 +399,11 @@ module name as parameter. Your code must C<use> or C<require> the
 module it specifies here. Alternatively, the blessed instance of
 a plug-in may be given.
 
-B<Warning: The entire plug-in API is currently highly experimental.>
-
 Details on the implementation of plug-ins including descriptions of
-individual events are provided in L<Neo4j::Driver::Plugins>.
+individual events are provided in L<Neo4j::Driver::Plugin>.
+
+This config option is experimental because some parts of the plug-in
+API are still evolving.
 
 =head2 Concurrent transactions in HTTP sessions
 

--- a/lib/Neo4j/Driver.pm
+++ b/lib/Neo4j/Driver.pm
@@ -172,6 +172,7 @@ sub _parse_options {
 		$options{cypher_params} = v2;
 	}
 	warnings::warnif deprecated => "Config option jolt is deprecated: Jolt is now enabled by default" if defined $options{jolt};
+	warnings::warnif deprecated => "Config option net_module is deprecated; use plug-in interface" if defined $options{net_module};
 	
 	my @unsupported = ();
 	foreach my $key (keys %options) {
@@ -288,15 +289,9 @@ See L</"uri"> for details.
 
 B<This driver's development is not yet considered finalised.>
 
-As of version 0.30, the major open items are:
+As of version 0.31, the major open items are:
 
 =over
-
-=item *
-
-Finalising the API for custom networking modules.
-(This is expected to require moving closer to a plugin API,
-in addition to formal specification of the result handler API.)
 
 =item *
 
@@ -392,31 +387,6 @@ These are subject to unannounced modification or removal in future
 versions. Expect your code to break if you depend upon these
 features.
 
-=head2 Custom networking modules
-
- use Local::MyNetworkAgent;
- $driver->config(net_module => 'Local::MyNetworkAgent');
-
-The module to be used for network communication may be specified
-using the C<net_module> config option. The specified module must
-implement the API described in L<Neo4j::Driver::Net/"EXTENSIONS">.
-Your code must C<use> or C<require> the module it specifies here.
-
-By default, the driver will try to auto-detect a suitable module.
-This will currently always result in the driver's built-in modules
-being used. Alternatively, you may specify the empty string to ask
-for the built-in modules explicitly, which will disable
-auto-detection.
-
- $driver->config(net_module => undef);  # auto-detect (the default)
- $driver->config(net_module => '');     # use the built-in modules
-
-This config option is experimental because the API for custom
-networking modules is in the process of being replaced by
-L<Neo4j::Driver::Plugin/"http_adapter_factory">.
-Existing networking modules will work as plugins
-with only minimal changes.
-
 =head2 Plug-in modules
 
  $driver->plugin( 'Local::MyPlugin' );
@@ -505,7 +475,7 @@ L<Neo4j::Driver> implements the following configuration options.
 
 Specifies the authentication details for the Neo4j server.
 The authentication details are provided as a Perl reference
-that is made available to the networking module. Typically,
+that is made available to the network adapter. Typically,
 this is an unblessed hash reference with the authentication
 scheme declared in the hash entry C<scheme>.
 

--- a/lib/Neo4j/Driver/Deprecations.pod
+++ b/lib/Neo4j/Driver/Deprecations.pod
@@ -47,6 +47,81 @@ consistent with the C<tls> option, then later renamed C<trust_ca>
 in S<version 0.27> to be more consistent with the Neo4j Driver API.
 See L<Neo4j::Driver/"trust_ca">.
 
+=head2 Custom networking modules
+
+I<Deprecated in version 0.31 and to be removed in 1.00.
+Originally added in 0.21 as an experimental feature.>
+
+ use Local::MyNetModule;
+ $driver->config(net_module => 'Local::MyNetModule');
+
+The module to be used for network communication may be specified
+using the C<net_module> config option. The specified module must
+implement the API described in L<Neo4j::Driver::Net/"EXTENSIONS">.
+Your code must C<use> or C<require> the module it specifies here.
+
+The default value of C<undef> will cause the driver to use its
+built-in modules. An empty string C<""> will do the same.
+
+ # use the built-in networking modules
+ $driver->config(net_module => undef);
+ $driver->config(net_module => '');
+
+Some versions of the driver also allow users to run its test suite
+against a custom net module.
+
+ TEST_NEO4J_NETMODULE=Local::MyNetModule prove
+
+The C<net_module> option provides decent flexibility for extending
+the driver. However, some interesting possible extensions have
+little to do with networking, and the C<net_module> API itself
+lacks flexibility.
+
+Existing networking modules should be converted to HTTP network
+adapters. This is easily done with the the following two steps.
+
+=over
+
+=item 1.
+
+Rename your existing C<sub new {}> constructor to (for example)
+C<sub _net_module_new {}>.
+
+=item 2.
+
+Insert the following code into your module:
+
+ use parent 'Neo4j::Driver::Plugin';
+ 
+ sub new {
+   bless [], shift;
+ }
+ 
+ sub register {
+   my ($self, $manager) = @_;
+   $manager->add_event_handler(
+     http_adapter_factory => sub {
+       my ($continue, $driver) = @_;
+       __PACKAGE__->_net_module_new($driver);
+     },
+   );
+ }
+
+See L<Neo4j::Driver::Plugin/"http_adapter_factory"> for details.
+
+=back
+
+At that point, your code setting the C<net_module> config option
+can simply be replaced by calls to L<Neo4j::Driver/"plugin">.
+
+ # Deprecated config option:
+ use Local::Foo;
+ $driver->config( net_module => 'Local::Foo' );
+ 
+ # New plug-in interface:
+ use Local::Foo;
+ $driver->plugin( 'Local::Foo' );
+
 =head2 Disable or enforce Jolt
 
 I<Deprecated in version 0.30 and to be removed in 1.00.
@@ -71,7 +146,7 @@ This option is no longer useful. The driver will pick the fastest
 and most reliable format automatically (S<RFC 7464> sparse Jolt, if
 available). If you do need a specific response format, for example
 because you use driver internals to access the raw server response,
-you can use a custom networking module to manipulate the HTTP
+you can use a plug-in to manipulate the HTTP
 C<Accept> header according to your needs. See L<Neo4j::Driver::Net>.
 
 =head2 Mutable auth credentials
@@ -100,7 +175,7 @@ supported by Neo4j S<versions 2 and 3> to the new syntax C<$param>
 supported by Neo4j S<versions 3 and 4>.
 
 This option was meant to support more general filtering of Cypher
-statements at some point in the future. But custom net modules
+statements at some point in the future. But plug-ins
 already make that very easy. Therefore the C<cypher_filter>
 option won't be extended any further. However, the existing
 parameter syntax conversion is probably useful enough to stand
@@ -552,7 +627,7 @@ will likely not be removed soon, but going forward, it will be
 treated as an internal API. There will be no deprecation warning.
 See L<Neo4j::Driver::Plugin/"USE OF INTERNAL APIS">.
 
-To disable query stats in future, use a custom networking module
+To disable query stats in future, use a plug-in
 to modify C<includeStats> in the server request.
 
 =head2 Return results in graph format
@@ -574,7 +649,7 @@ L<"graph" results data format|https://neo4j.com/docs/http-api/4.4/actions/return
 This feature is only available when Jolt is disabled, which is
 not recommended.
 
-To request graph format in future, use a custom networking module
+To request graph format in future, use a plug-in
 to disable Jolt and modify the C<resultDataContents> in the server
 request. Note that C<< $record->{graph} >> is an internal API that
 may or may not be available in future versions.
@@ -615,7 +690,7 @@ not a transaction was successful or rolled back.
 
 Given the low availability and reliability of this indicator,
 consistency suggests to remove the C<deleted()> method entirely.
-To obtain this indicator in the future, use a custom net module
+To obtain this indicator in the future, use a plug-in
 to disable Jolt, then try to access the result's raw meta data.
 For caveats, see L<Neo4j::Driver::Plugin/"USE OF INTERNAL APIS">.
 

--- a/lib/Neo4j/Driver/Deprecations.pod
+++ b/lib/Neo4j/Driver/Deprecations.pod
@@ -550,7 +550,7 @@ between Bolt and HTTP connections are very clear. The driver
 currently uses C<{return_stats} = 0> internally, so this feature
 will likely not be removed soon, but going forward, it will be
 treated as an internal API. There will be no deprecation warning.
-See L<Neo4j::Driver::Net/"USE OF INTERNAL APIS">.
+See L<Neo4j::Driver::Plugin/"USE OF INTERNAL APIS">.
 
 To disable query stats in future, use a custom networking module
 to modify C<includeStats> in the server request.
@@ -578,7 +578,7 @@ To request graph format in future, use a custom networking module
 to disable Jolt and modify the C<resultDataContents> in the server
 request. Note that C<< $record->{graph} >> is an internal API that
 may or may not be available in future versions.
-See L<Neo4j::Driver::Net/"USE OF INTERNAL APIS">.
+See L<Neo4j::Driver::Plugin/"USE OF INTERNAL APIS">.
 
 If there is demand for the graph format, equivalent functionality
 might be added to a future version of the driver itself.
@@ -617,7 +617,7 @@ Given the low availability and reliability of this indicator,
 consistency suggests to remove the C<deleted()> method entirely.
 To obtain this indicator in the future, use a custom net module
 to disable Jolt, then try to access the result's raw meta data.
-For caveats, see L<Neo4j::Driver::Net/"USE OF INTERNAL APIS">.
+For caveats, see L<Neo4j::Driver::Plugin/"USE OF INTERNAL APIS">.
 
 =head1 Neo4j::Driver::Type::Path
 

--- a/lib/Neo4j/Driver/Net.pod
+++ b/lib/Neo4j/Driver/Net.pod
@@ -269,13 +269,8 @@ method L<Neo4j::Driver/"config"> only.
 
 =head2 Custom result handlers
 
-The result handler API is currently not formally specified.
-It is an internal API that is still evolving and may be subject
-to unannounced change.
-
-Even so, it's fully possible to implement a custom result handler.
-You should probably drop me a line when you begin work on one;
-see L</"USE OF INTERNAL APIS">.
+This section has been replaced by
+L<Neo4j:::Driver::Plugin/"Result handler API">.
 
 =head1 USE OF INTERNAL APIS
 

--- a/lib/Neo4j/Driver/Net.pod
+++ b/lib/Neo4j/Driver/Net.pod
@@ -21,37 +21,21 @@
 B<WARNING:> Some of these calls are private APIs.
 See L<Neo4j:::Driver::Plugin/"USE OF INTERNAL APIS">.
 
-=head1 WARNING: EXPERIMENTAL
-
-The design of the networking helper APIs is not entirely finalised.
-In particular, the driver's C<net_module> config option is in the
-process of being replaced by L<Neo4j::Driver/"plugin">, allowing for
-multiple plugins instead of just a single module. Existing
-networking modules will work as plugins with only minimal changes.
-
-You should probably
-let me know if you already are creating networking extensions, so
-that I can try to accommodate your use case and give you advance
-notice of changes.
-
-The driver's C<net_module> config option is
-L<experimental|Neo4j::Driver/"Custom networking modules"> as well.
-
 =head1 OVERVIEW
 
-Each L<Neo4j::Driver::Session> has exactly one networking helper
+Each L<Neo4j::Driver::Session> has exactly one network controller
 instance that is used by the session and all of its transactions
 to communicate with the Neo4j server. This document discusses the
-features and known limitations of the networking helpers.
+features and known limitations of the network controllers.
 
-B<Unless you're planning to develop custom networking modules
+B<Unless you're planning to develop custom network adapters
 for the driver, you probably don't need to read this document.>
 
-The helpers don't communicate with the server directly. Instead,
-they control another module that has responsibility for the actual
-network transmissions. This module can be customised by using the
-driver's C<net_module> config option. The API that custom networking
-modules need to implement is described in L</"EXTENSIONS"> below.
+The controllers don't communicate with the server directly. Instead,
+they use another module that has responsibility for the actual
+network transmissions. For HTTP connections, that other module can
+be customised via L<Neo4j::Driver::Plugin/"http_adapter_factory">.
+For Bolt, see L</"EXTENSIONS"> below.
 
 Network responses received from the server will be parsed for Neo4j
 statement results by the appropriate result handler for the response
@@ -59,7 +43,7 @@ format used by the server. A custom networking module can also
 provide custom response parsers, for example implemented in XS code.
 
 Please note that the division of labour between sessions or
-transactions on the one hand and networking helpers on the other
+transactions on the one hand and networking controllers on the other
 hand is an internal implementation detail of the driver and as such
 is B<subject to unannounced change.> While some of those details are
 explained in this document, this is done only to help contributors
@@ -69,7 +53,7 @@ information on this topic.
 
 =head1 FEATURES
 
-The networking helpers primarily deal with the following tasks:
+The networking controllers primarily deal with the following tasks:
 
 =over
 
@@ -96,7 +80,7 @@ supports both Jolt and JSON as result formats. There is also
 a fallback result handler, which is used to parse error
 messages out of C<text/*> responses. The HTTP result handlers
 are individually queried for the media types they support.
-This information is cached by the networking helper.
+This information is cached by the networking controller.
 
 All result handlers inherit a common interface from
 L<Neo4j::Driver::Result>. They provide methods to initialise and
@@ -123,7 +107,7 @@ transaction endpoints, the Neo4j
 L<Transactional HTTP API|https://neo4j.com/docs/http-api/4.2/actions/>
 always provides transaction status information in the response.
 Transactions that remain open include an expiration time. The
-networking helper parses and stores this timestamp and uses it to
+networking controller parses and stores this timestamp and uses it to
 track which transactions are still open and which have timed out.
 The origination C<Date> field is used to synchronise the clocks
 of the driver and the Neo4j server
@@ -147,7 +131,7 @@ these rollbacks take place immediately. On Bolt, however, the
 transaction is typically only marked as uncommittable on the Neo4j
 server, but the Bolt connection is not actually put into the
 C<FAILED> state immediately. To try and work around this difference
-between HTTP and Bolt, this driver's Bolt networking handler always
+between HTTP and Bolt, this driver's Bolt network controller always
 attempts an explicit transaction rollback if faced with any error
 condition. Again, this approach mostly gets it right, but there
 may be some remaining issues, particularly when network errors and
@@ -186,7 +170,7 @@ into account network delays. In case of high network latency, the
 driver may treat transactions as open even though they have already
 expired on the server. To address this, you could either increase
 the transaction idle timeout in F<neo4j.conf> or manipulate the
-return value of C<date_header()> in a custom networking module.
+return value of C<date_header()> in a custom network adapter.
 
 The metadata in HTTP JSON responses is often insufficient to fully
 describe the response data. In particular:
@@ -213,6 +197,10 @@ in all response format parsers.
 
 =head1 EXTENSIONS
 
+The C<net_module> config option available in driver S<versions 0.21>
+S<through 0.30> has been replaced with an experimental plug-in API;
+see L<Neo4j::Driver::Deprecations/"Custom networking modules">.
+
 =head2 Custom Bolt networking modules
 
 By default, Bolt networking uses the amazing XS module
@@ -222,33 +210,30 @@ to actually connect to the Neo4j server. Updates and improvements
 are quite possibly best made directly in those libraries, so that
 not only L<Neo4j::Driver>, but also other users benefit from them.
 
-If the driver's C<net_module> config option is used with a Bolt
-connection, the module name provided will be used in place of
-L<Neo4j::Bolt> and will have to match its API I<exactly.>
-It is possible to provide a factory object instead.
+There is currently no public API for custom Bolt network adapters;
+see L<Neo4j::Driver::Plugin/"Network adapter API for Bolt">.
+However, the driver's test suite still uses the former C<net_module>
+option internally, so it will remain available for the time being.
 
-Results will be handled by L<Neo4j::Driver::Result::Bolt>, unless a
-custom C<net_module> provides a method named C<result_handlers()>.
-If it does, it's expected to return a list containing a single
-module name, which will be used as a result handler instead.
-See L</"Custom result handlers"> below.
+ use Local::MyBolt;
+ $driver->config(uri => 'bolt://...');
+ $driver->{net_module} = 'Local::MyBolt';  # private API
+
+The module name provided will be used in place of
+L<Neo4j::Bolt> and will have to match its API I<exactly.>
+Note that there is no support for this approach. For details,
+see L<Neo4j:::Driver::Plugin/"USE OF INTERNAL APIS">.
 
 =head2 Custom HTTP networking modules
 
-L<Neo4j::Driver> includes a single HTTP networking module that will
-be used if the C<net_module> config option is set to C<""> or
-C<undef> (the default). If another module name is given as
-C<net_module>, that module will be used instead of the included
-module. Make sure you always C<use> a custom networking module.
-If you extend the included module through inheritance, you also
-must C<use parent>.
-
-The included module may change in future. As of S<version 0.21>,
-the default module uses L<LWP> directly. Earlier versions used
+L<Neo4j::Driver> includes a default HTTP network adapter.
+The included adapter may change in future. As of S<version 0.21>,
+the default adapter uses L<LWP> directly. Earlier versions used
 L<REST::Client>.
 
-Modules to be used as C<net_module> must implement the API
-for an HTTP adapter; see
+The driver's test suite still uses the former C<net_module>
+option internally. Modules to be used as C<net_module> must
+implement the API for an HTTP adapter; see
 L<Neo4j:::Driver::Plugin/"Network adapter API for HTTP">.
 Additionally, they must implement the following method:
 

--- a/lib/Neo4j/Driver/Net.pod
+++ b/lib/Neo4j/Driver/Net.pod
@@ -273,16 +273,19 @@ response.
 
 HTTP networking modules must implement the following methods.
 
-The driver will make all method calls using the arrow operator
-(C<< -> >>). The method descriptions below use a syntax similar to
-that of C<use feature 'signatures'>; however, the first argument
-(C<$class> or C<$self>) is omitted from the signatures for clarity.
+Be warned that future updates to the driver may change this API
+such that existing methods need to accept additional parameters.
+If you use subroutine signatures, you should end them with C<@>
+in order to prevent arity errors.
 
 =over
 
 =item date_header
 
- sub date_header () { $date }
+ sub date_header {
+   my ($self) = @_;
+   ...
+ }
 
 Return the HTTP C<Date:> header from the last response as string.
 If the server doesn't have a clock, the header will be missing;
@@ -294,7 +297,10 @@ May block until the response headers have been fully received.
 
 =item fetch_all
 
- sub fetch_all () { $response_content }
+ sub fetch_all {
+   my ($self) = @_;
+   ...
+ }
 
 Block until the response to the last network request has been fully
 received, then return the entire content of the response buffer.
@@ -305,7 +311,10 @@ the same request is undefined.
 
 =item fetch_event
 
- sub fetch_event () { $next_event }
+ sub fetch_event {
+   my ($self) = @_;
+   ...
+ }
 
 Return the next Jolt event from the response to the last network
 request as a string. When there are no further Jolt events, this
@@ -320,7 +329,10 @@ C<fetch_all()> has already been called for the same request.
 
 =item http_header
 
- sub http_header () { \%headers }
+ sub http_header {
+   my ($self) = @_;
+   ...
+ }
 
 Return a hashref with the following entries, representing
 headers and status of the last response.
@@ -343,7 +355,10 @@ Blocks until the response headers have been fully received.
 
 =item http_reason
 
- sub http_reason () { $reason_phrase }
+ sub http_reason {
+   my ($self) = @_;
+   ...
+ }
 
 Return the HTTP reason phrase (S<e. g.> C<"Not Found"> for
 status 404). If unavailable, C<""> is returned instead.
@@ -351,7 +366,10 @@ May block until the response headers have been fully received.
 
 =item json_coder
 
- sub json_coder () { $json_coder }
+ sub json_coder {
+   my ($self) = @_;
+   ...
+ }
 
 Return a L<JSON::XS>-compatible coder object (for result parsers).
 It must offer a method C<decode()> that can handle the return
@@ -364,7 +382,10 @@ of L<JSON::MaybeXS>.
 
 =item new
 
- sub new ($driver) { $self }
+ sub new {
+   my ($class, $driver) = @_;
+   ...
+ }
 
 Initialises the object. May or may not establish a network
 connection. May access C<$driver> config options using the
@@ -372,7 +393,10 @@ method L<Neo4j::Driver/"config"> only.
 
 =item request
 
- sub request ($method, $url, $json, $accept) { }
+ sub request {
+   my ($self, $method, $url, $json, $accept) = @_;
+   ...
+ }
 
 Start an HTTP request on the network. The following positional
 parameters are given:
@@ -406,7 +430,10 @@ has been received.
 
 =item result_handlers
 
- sub result_handlers () { @module_names }
+ sub result_handlers {
+   my ($self) = @_;
+   ...
+ }
 
 Return a list of result handler modules to be used to parse
 Neo4j statement results delivered through this module.
@@ -417,7 +444,10 @@ See L</"Custom result handlers"> below.
 
 =item uri
 
- sub uri () { $uri }
+ sub uri {
+   my ($self) = @_;
+   ...
+ }
 
 Return the server base URL as string or L<URI> object
 (for L<Neo4j::Driver::ServerInfo>).

--- a/lib/Neo4j/Driver/Net.pod
+++ b/lib/Neo4j/Driver/Net.pod
@@ -19,7 +19,7 @@
  $json_coder->decode( $helper->{http_agent}->fetch_all );
 
 B<WARNING:> Some of these calls are private APIs.
-See L</"USE OF INTERNAL APIS">.
+See L<Neo4j:::Driver::Plugin/"USE OF INTERNAL APIS">.
 
 =head1 WARNING: EXPERIMENTAL
 
@@ -64,7 +64,8 @@ hand is an internal implementation detail of the driver and as such
 is B<subject to unannounced change.> While some of those details are
 explained in this document, this is done only to help contributors
 and users of I<public> APIs better understand the driver's design.
-See L</"USE OF INTERNAL APIS"> for more information on this topic.
+See L<Neo4j:::Driver::Plugin/"USE OF INTERNAL APIS"> for more
+information on this topic.
 
 =head1 FEATURES
 
@@ -467,33 +468,7 @@ see L</"USE OF INTERNAL APIS">.
 
 =head1 USE OF INTERNAL APIS
 
-B<Public APIs> generally include everything that is documented
-in POD. However, I<this> document may contain some mentions of
-I<private> APIs (where it does, it tries to be explicit about it).
-The section L</"Custom HTTP networking modules"> describes a
-public API.
-
-B<Private internals,> on the other hand, include all package-global
-variables (C<our ...>), all methods with names that begin with an
-underscore (C<_>) and I<all> cases of accessing the data structures
-of blessed objects directly (S<e. g.> C<< $session->{net} >>).
-Additionally, the C<new()> methods of packages without POD
-documentation of their own are to be considered private internals.
-
-You are of course free to use any driver internals in your own code,
-but if you do so, you also bear the sole responsibility for keeping
-it working after updates to the driver. Changes to internals are
-usually not announced in the F<Changes> list, so you should consider
-watching GitHub commits. It is discouraged to try this approach if
-your code is used in production.
-
-If you have difficulties achieving your goals without the use of
-driver internals or private APIs, you are most welcome to file a
-GitHub issue about that (or write to my CPAN email address with
-your concerns; make sure you mention Neo4j in the subject to beat
-the spam filters).
-
-I can't I<promise> that I'll be able to accommodate your use case,
-but I am going to try.
+This section has been replaced by
+L<Neo4j:::Driver::Plugin/"USE OF INTERNAL APIS">.
 
 =cut

--- a/lib/Neo4j/Driver/Net.pod
+++ b/lib/Neo4j/Driver/Net.pod
@@ -24,8 +24,8 @@ See L<Neo4j:::Driver::Plugin/"USE OF INTERNAL APIS">.
 =head1 WARNING: EXPERIMENTAL
 
 The design of the networking helper APIs is not entirely finalised.
-In particular, it is expected that the driver's C<net_module> config
-option will be replaced with a new option that allows specifying
+In particular, the driver's C<net_module> config option is in the
+process of being replaced by L<Neo4j::Driver/"plugin">, allowing for
 multiple plugins instead of just a single module. Existing
 networking modules will work as plugins with only minimal changes.
 
@@ -247,139 +247,12 @@ The included module may change in future. As of S<version 0.21>,
 the default module uses L<LWP> directly. Earlier versions used
 L<REST::Client>.
 
-It is possible to set a factory object as C<net_module> instead of
-providing a module name. The factory object must have a C<new()>
-method returning an object that implements the interface described
-in the following section.
-
-If you look at the source of existing networking modules for
-inspiration, please note that they may use internal APIs.
-Please make sure you read L</"USE OF INTERNAL APIS"> before you
-start copying existing code.
-
-=head3 API of an HTTP networking module
-
-The driver primarily uses HTTP networking modules by first calling
-the C<request()> method, which initiates a request on the network,
-and then calling other methods to obtain information about the
-response.
-
- $net_module = $driver->config('net_module');
- $agent = $net_module->new($driver);
- 
- $agent->request('GET', '/', undef, 'application/json');
- $status  = $agent->http_header->{status};
- $type    = $agent->http_header->{content_type};
- $content = $agent->fetch_all;
-
-HTTP networking modules must implement the following methods.
-
-Be warned that future updates to the driver may change this API
-such that existing methods need to accept additional parameters.
-If you use subroutine signatures, you should end them with C<@>
-in order to prevent arity errors.
+Modules to be used as C<net_module> must implement the API
+for an HTTP adapter; see
+L<Neo4j:::Driver::Plugin/"Network adapter API for HTTP">.
+Additionally, they must implement the following method:
 
 =over
-
-=item date_header
-
- sub date_header {
-   my ($self) = @_;
-   ...
- }
-
-Return the HTTP C<Date:> header from the last response as string.
-If the server doesn't have a clock, the header will be missing;
-in this case, the value returned must be either the empty
-string or (optionally) the current time in non-obsolete
-L<RFC5322:3.3|https://tools.ietf.org/html/rfc5322#section-3.3>
-format.
-May block until the response headers have been fully received.
-
-=item fetch_all
-
- sub fetch_all {
-   my ($self) = @_;
-   ...
- }
-
-Block until the response to the last network request has been fully
-received, then return the entire content of the response buffer.
-
-This method must generally be idempotent, but the behaviour of this
-method if called after C<fetch_event()> has already been called for
-the same request is undefined.
-
-=item fetch_event
-
- sub fetch_event {
-   my ($self) = @_;
-   ...
- }
-
-Return the next Jolt event from the response to the last network
-request as a string. When there are no further Jolt events, this
-method returns an undefined value. If the response hasn't been
-fully received at the time this method is called and the internal
-response buffer does not contain at least one event, this method
-will block until at least one event is available.
-
-The behaviour of this method is undefined for responses that
-are not in Jolt format. The behaviour is also undefined if
-C<fetch_all()> has already been called for the same request.
-
-=item http_header
-
- sub http_header {
-   my ($self) = @_;
-   ...
- }
-
-Return a hashref with the following entries, representing
-headers and status of the last response.
-
-=over
-
-=item * C<content_type> – S<e. g.> C<"application/json">
-
-=item * C<location> – URI reference
-
-=item * C<status> – status code, S<e. g.> C<"404">
-
-=item * C<success> – truthy for 2xx status codes
-
-=back
-
-All of these entries must exist and be defined scalars.
-Unavailable values must use the empty string.
-Blocks until the response headers have been fully received.
-
-=item http_reason
-
- sub http_reason {
-   my ($self) = @_;
-   ...
- }
-
-Return the HTTP reason phrase (S<e. g.> C<"Not Found"> for
-status 404). If unavailable, C<""> is returned instead.
-May block until the response headers have been fully received.
-
-=item json_coder
-
- sub json_coder {
-   my ($self) = @_;
-   ...
- }
-
-Return a L<JSON::XS>-compatible coder object (for result parsers).
-It must offer a method C<decode()> that can handle the return
-values of C<fetch_event()> and C<fetch_all()> (which may be
-expected to be a byte sequence that is valid UTF-8) and should
-produce C<$JSON::PP::true> and C<$JSON::PP::false> for booleans.
-
-The default module included with the driver returns an instance
-of L<JSON::MaybeXS>.
 
 =item new
 
@@ -391,68 +264,6 @@ of L<JSON::MaybeXS>.
 Initialises the object. May or may not establish a network
 connection. May access C<$driver> config options using the
 method L<Neo4j::Driver/"config"> only.
-
-=item request
-
- sub request {
-   my ($self, $method, $url, $json, $accept) = @_;
-   ...
- }
-
-Start an HTTP request on the network. The following positional
-parameters are given:
-
-=over
-
-=item * C<$method> – HTTP method, S<e. g.> C<"POST">
-
-=item * C<$url> – string with request URL
-
-=item * C<$json> – reference to hash of JSON object
-
-=item * C<$accept> – string with value for the C<Accept:> header
-
-=back
-
-The request C<$url> is to be interpreted relative to the server
-base URL given in the driver config.
-
-The C<$json> hashref must be serialised before transmission.
-It may include booleans encoded as the values C<\1> and C<\0>.
-For requests to be made without request content, the value
-of C<$json> will be C<undef>.
-
-C<$accept> will have different values depending on C<$method>;
-this is a workaround for a known issue in the Neo4j server
-(L<#12644|https://github.com/neo4j/neo4j/issues/12644>).
-
-The C<request()> method may or may not block until the response
-has been received.
-
-=item result_handlers
-
- sub result_handlers {
-   my ($self) = @_;
-   ...
- }
-
-Return a list of result handler modules to be used to parse
-Neo4j statement results delivered through this module.
-The module names returned will be used in preference to the
-result handlers built into the driver.
-
-See L</"Custom result handlers"> below.
-
-=item uri
-
- sub uri {
-   my ($self) = @_;
-   ...
- }
-
-Return the server base URL as string or L<URI> object
-(for L<Neo4j::Driver::ServerInfo>).
-At least scheme, host, and port must be included.
 
 =back
 

--- a/lib/Neo4j/Driver/Net/Bolt.pm
+++ b/lib/Neo4j/Driver/Net/Bolt.pm
@@ -4,7 +4,7 @@ use warnings;
 use utf8;
 
 package Neo4j::Driver::Net::Bolt;
-# ABSTRACT: Networking delegate for Neo4j Bolt
+# ABSTRACT: Network controller for Neo4j Bolt
 
 
 # This package is not part of the public Neo4j::Driver API.

--- a/lib/Neo4j/Driver/Net/HTTP.pm
+++ b/lib/Neo4j/Driver/Net/HTTP.pm
@@ -4,7 +4,7 @@ use warnings;
 use utf8;
 
 package Neo4j::Driver::Net::HTTP;
-# ABSTRACT: Networking delegate for Neo4j HTTP
+# ABSTRACT: Network controller for Neo4j HTTP
 
 
 # This package is not part of the public Neo4j::Driver API.

--- a/lib/Neo4j/Driver/Net/HTTP.pm
+++ b/lib/Neo4j/Driver/Net/HTTP.pm
@@ -132,7 +132,8 @@ sub _accept_for {
 	my ($self, $method) = @_;
 	
 	# GET requests may fail if Neo4j sees clients that support Jolt, see neo4j #12644
-	my @modules = ( $self->{http_agent}->result_handlers, @RESULT_MODULES );
+	my @modules = @RESULT_MODULES;
+	unshift @modules, $self->{http_agent}->result_handlers if $self->{http_agent}->can('result_handlers');
 	my @accept = map { $_->_accept_header( $self->{want_jolt}, $method ) } @modules;
 	return $self->{accept_for}->{$method} = join ', ', @accept;
 }
@@ -143,7 +144,8 @@ sub _accept_for {
 sub _result_module_for {
 	my ($self, $content_type) = @_;
 	
-	my @modules = ( $self->{http_agent}->result_handlers, @RESULT_MODULES );
+	my @modules = @RESULT_MODULES;
+	unshift @modules, $self->{http_agent}->result_handlers if $self->{http_agent}->can('result_handlers');
 	foreach my $module (@modules) {
 		if ($module->_acceptable($content_type)) {
 			return $self->{result_module_for}->{$content_type} = $module;

--- a/lib/Neo4j/Driver/Net/HTTP/LWP.pm
+++ b/lib/Neo4j/Driver/Net/HTTP/LWP.pm
@@ -4,7 +4,7 @@ use warnings;
 use utf8;
 
 package Neo4j::Driver::Net::HTTP::LWP;
-# ABSTRACT: HTTP agent adapter for libwww-perl
+# ABSTRACT: HTTP network adapter for libwww-perl
 
 
 use Carp qw(croak);
@@ -144,16 +144,24 @@ __END__
 
 =head1 SYNOPSIS
 
- use Neo4j::Driver::Net::HTTP::LWP;
- $driver->config( net_module => 'Neo4j::Driver::Net::HTTP::LWP' );
+ use parent 'Neo4j::Driver::Plugin';
+ 
+ sub register {
+   my ($self, $manager) = @_;
+   $manager->add_event_handler(
+     http_adapter_factory => sub {
+       my ($continue, $driver) = @_;
+       my $adapter = Neo4j::Driver::Net::HTTP::LWP->new($driver);
+       ...
+       return $adapter;
+     },
+   );
+ }
 
 You can also extend this module through inheritance:
 
- use Local::MyProxy;
- $driver->config( net_module => 'Local::MyProxy' );
- 
- package Local::MyProxy;
  use parent 'Neo4j::Driver::Net::HTTP::LWP';
+ 
  sub new {
    my $self = shift->SUPER::new(@_);
    $self->ua->proxy('http', 'http://proxy.example.net:8081/');
@@ -162,8 +170,8 @@ You can also extend this module through inheritance:
 
 =head1 DESCRIPTION
 
-The L<Neo4j::Driver::Net::HTTP::LWP> package is an HTTP networking
-module for L<Neo4j::Driver>, using L<LWP::UserAgent> to connect to
+The L<Neo4j::Driver::Net::HTTP::LWP> package is an HTTP network
+adapter for L<Neo4j::Driver>, using L<LWP::UserAgent> to connect to
 the Neo4j server via HTTP or HTTPS.
 
 HTTPS connections require L<LWP::Protocol::https> to be installed.
@@ -217,7 +225,7 @@ configures it using the given L<Neo4j::Driver>.
  }
 
 Returns the L<LWP::UserAgent> instance in use.
-Meant to facilitate subclassing.
+Meant to facilitate reuse.
 
 =head1 BUGS
 

--- a/lib/Neo4j/Driver/Net/HTTP/LWP.pm
+++ b/lib/Neo4j/Driver/Net/HTTP/LWP.pm
@@ -85,8 +85,6 @@ sub uri { shift->{uri_base} }
 
 sub json_coder { shift->{json_coder} }
 
-sub result_handlers { }
-
 sub http_reason { shift->{response}->message // '' }
 
 sub date_header { scalar shift->{response}->header('Date') // '' }
@@ -190,8 +188,6 @@ see L<Neo4j::Driver::Plugin/"Network adapter API for HTTP">.
 =item * C<json_coder>
 
 =item * C<request>
-
-=item * C<result_handlers>
 
 =item * C<uri>
 

--- a/lib/Neo4j/Driver/Net/HTTP/LWP.pm
+++ b/lib/Neo4j/Driver/Net/HTTP/LWP.pm
@@ -173,7 +173,7 @@ HTTPS connections require L<LWP::Protocol::https> to be installed.
 =head1 METHODS
 
 L<Neo4j::Driver::Net::HTTP::LWP> implements the following methods;
-see L<Neo4j::Driver::Net/"API of an HTTP networking module">.
+see L<Neo4j::Driver::Plugin/"Network adapter API for HTTP">.
 
 =over
 
@@ -189,8 +189,6 @@ see L<Neo4j::Driver::Net/"API of an HTTP networking module">.
 
 =item * C<json_coder>
 
-=item * C<new>
-
 =item * C<request>
 
 =item * C<result_handlers>
@@ -204,7 +202,14 @@ has been fully received. Therefore none of the other methods will
 ever block.
 
 In addition to the methods listed above,
-L<Neo4j::Driver::Net::HTTP::LWP> implements the following method.
+L<Neo4j::Driver::Net::HTTP::LWP> implements the following methods.
+
+=head2 new
+
+ $adapter = Neo4j::Driver::Net::HTTP::LWP->new( $driver );
+
+Creates a new L<Neo4j::Driver::Net::HTTP::LWP> adapter and
+configures it using the given L<Neo4j::Driver>.
 
 =head2 ua
 

--- a/lib/Neo4j/Driver/Plugin.pm
+++ b/lib/Neo4j/Driver/Plugin.pm
@@ -14,11 +14,14 @@ package Neo4j::Driver::Plugin;
 
  package Local::MyNeo4jPlugin;
  use parent 'Neo4j::Driver::Plugin';
- use feature 'signatures';
  
- sub new ($class) { bless {}, $class }
+ sub new {
+   my ($class) = @_;
+   return bless {}, $class;
+ }
  
- sub register ($self, $manager, @) {
+ sub register {
+   my ($self, $manager) = @_;
    $manager->add_event_handler(
      http_adapter_factory => sub {
        Local::MyNeo4jLWPAdapter->new();
@@ -38,11 +41,7 @@ package Neo4j::Driver::Plugin;
 
 =head1 WARNING: EXPERIMENTAL
 
-Take great care when implementing plug-ins, because even small
-deviations from this specification may cause your code to break
-with future versions of the driver in non-obvious ways.
-
-Additionally, the design of the plug-in API is not finalised.
+The design of the plug-in API is not finalised.
 You should probably let me know if you already are writing
 plug-ins, so that I can try to accommodate your use case
 and give you advance notice of changes.
@@ -98,7 +97,8 @@ Future versions may introduce new events or remove existing ones.
 =item http_adapter_factory
 
  $manager->add_event_handler(
-   http_adapter_factory => sub ($continue, $driver, @) {
+   http_adapter_factory => sub {
+     my ($continue, $driver) = @_;
      my $adapter;
      ...
      return $adapter // $continue->();
@@ -108,8 +108,7 @@ Future versions may introduce new events or remove existing ones.
 This event is triggered when a new HTTP adapter instance is
 needed during session creation. Parameters given are a code
 reference for continuing with the next handler registered for
-this event, the driver, and an indeterminate number of extra
-arguments that are to be ignored.
+this event and the driver.
 
 A handler for this event must return the blessed instance of
 an HTTP adapter module (formerly known as "networking module")
@@ -140,19 +139,23 @@ The plug-in itself must implement the following methods.
 
 =item new
 
- sub new ($class, @) { ... }
+ sub new {
+   my ($class) = @_;
+   ...
+ }
 
 Plug-in constructor. Returns a blessed reference. Parameters
-given are the plug-in package name and an indeterminate number
-of extra arguments that are to be ignored.
+given are the plug-in package name.
 
 =item register
 
- sub register ($self, $manager, @) { ... }
+ sub register {
+   my ($self, $manager) = @_;
+   ...
+ }
 
 Called by the driver when a plug-in is loaded. Parameters given
-are the plug-in, a plug-in manager, and an indeterminate number of
-extra arguments that are to be ignored.
+are the plug-in and a plug-in manager.
 
 This method is expected to attach this plug-in's event handlers
 by calling the plug-in manager's L</"add_event_handler"> method.
@@ -184,10 +187,10 @@ is triggered, the handler will be invoked (unless another plug-in's
 handler for the same event prevents this). Handlers will not be
 invoked in any particular defined order.
 
-If you use signatures, take care to specify the correct arity for
-your handlers. Future updates to the driver may change existing
-events to provide more parameters. The correct way to specify the
-signature of an event handler is to end it with C<@>.
+Note that future updates to the driver may change existing events
+to provide additional arguments. Because subroutine signatures
+perform strict checks of the number of arguments, they are not
+recommended for event handlers.
 
 =item trigger_event
 

--- a/lib/Neo4j/Driver/Plugin.pm
+++ b/lib/Neo4j/Driver/Plugin.pm
@@ -1,11 +1,19 @@
-# PODNAME: Neo4j::Driver::Plugins
-# ABSTRACT: Specification of the driver's plug-in interface
+use 5.010;
+use strict;
+use warnings;
+
+package Neo4j::Driver::Plugin;
+# ABSTRACT: Plug-in interface for Neo4j::Driver
+
+
+1;
 
 =encoding utf8
 
 =head1 SYNPOSIS
 
  package Local::MyNeo4jPlugin;
+ use parent 'Neo4j::Driver::Plugin';
  use feature 'signatures';
  
  sub new ($class) { bless {}, $class }
@@ -68,6 +76,9 @@ have side effects. In some cases, an event can only be handled a
 single time, with any additional handlers being ignored. In some
 cases, the return value of an event handler may be significant.
 All of these API details are still evolving.
+
+Plug-ins must inherit from C<Neo4j::Driver::Plugin>. They must
+also implement the methods described in L</"METHODS"> below.
 
 I'm grateful for any feedback you I<(yes, you!)> might have on
 this driver's plug-in API. Please open a GitHub issue or get in

--- a/lib/Neo4j/Driver/Plugin.pm
+++ b/lib/Neo4j/Driver/Plugin.pm
@@ -46,9 +46,9 @@ You should probably let me know if you already are writing
 plug-ins, so that I can try to accommodate your use case
 and give you advance notice of changes.
 
-B<The entire plug-in API is currently highly experimental.>
+B<The entire plug-in API is currently experimental.>
 
-The driver's C<plugins()> method is
+The driver's C<plugin()> method is
 L<experimental|Neo4j::Driver/"Plug-in modules"> as well.
 
 =head1 OVERVIEW

--- a/lib/Neo4j/Driver/Plugin.pm
+++ b/lib/Neo4j/Driver/Plugin.pm
@@ -214,3 +214,33 @@ so might be treated specially by a future version of the driver.
 Use C<scalar> to be safe.
 
 =back
+
+=head1 USE OF INTERNAL APIS
+
+B<Public APIs> generally include everything that is documented
+in POD, unless explicitly noted otherwise.
+
+B<Private internals,> on the other hand, include all package-global
+variables (C<our ...>), all methods with names that begin with an
+underscore (C<_>) and I<all> cases of accessing the data structures
+of blessed objects directly (S<e. g.> C<< $session->{net} >>). In
+addition, methods without any POD documentation are to be considered
+private internals (S<e. g.> C<< Neo4j::Driver::Session->new() >>).
+
+You are of course free to use any driver internals in your own code,
+but if you do so, you also bear the sole responsibility to keep it
+working after updates to the driver. Changes to internals are often
+not announced in the F<Changes> list, so you should consider to
+watch GitHub commits. It is discouraged to try this approach if
+your code is used in production.
+
+If you have difficulties achieving your goals without the use of
+driver internals or private APIs, you are most welcome to file a
+GitHub issue about that (or write to my CPAN email address with
+your concerns; make sure you mention Neo4j in the subject to beat
+the spam filters).
+
+I can't I<promise> that I'll be able to accommodate your use case,
+but I am going to try.
+
+=cut

--- a/lib/Neo4j/Driver/Plugin.pm
+++ b/lib/Neo4j/Driver/Plugin.pm
@@ -408,6 +408,13 @@ Neo4j statement results delivered through this module.
 The module names returned will be used in preference to the
 result handlers built into the driver.
 
+Unlike any other method, C<result_handlers()> is optional for
+a Neo4j HTTP adapter module. It may only be implemented by
+network adapters that actually offer custom result handlers.
+Note that the result handler API is currently internal and
+expected to change, and this method will likely disappear
+entirely in future; see L</"RESULT HANDLER API"> below.
+
 =item uri
 
  sub uri {
@@ -420,6 +427,47 @@ Return the server base URL as string or L<URI> object
 At least scheme, host, and port must be included.
 
 =back
+
+=head2 Result handler API
+
+Making a Neo4j result handler API available to plug-ins will
+require significant internal changes to the driver. These
+are currently being postponed, at least until most of the
+L<deprecated functionality|Neo4j::Driver::Deprecations> has
+been removed from the driver's code base.
+
+Even then, the result handler API may have low priority.
+However, new plug-in events are anticipated in a future version
+that should enable clients to achieve some of the same goals.
+
+In the meantime, the result handler API remains not formally
+specified. It is an internal API that is evolving and may be
+subject to unannounced change; see L</"USE OF INTERNAL APIS">.
+
+A few notes on the result handler API that may or may not be
+accurate by the time you read this:
+
+ sub new ($class, $params) {}
+ sub _fetch_next ($self) {}
+   # ^ optional if results are always fully detached
+ sub _init_record ($self, $record) {}
+ 
+ # for HTTP additionally:
+ sub _accept_header ($, $want_jolt, $method) {}
+ sub _acceptable ($, $content_type) {}
+ sub _info ($self) {}
+ sub _json ($self) {}
+   # ^ only required for handlers that accept application/json
+   #   (solely used by the Discovery API to get raw JSON)
+ 
+ # For the API, these methods should gain public names (no _).
+ # Currently the driver's own result handlers access the internal
+ # data structures directly. For the API, some kind of accessors
+ # will be needed, and for simplicity, all results should always
+ # begin as attached (JSON: $fake_attached = 1).
+
+B<WARNING:> All of these methods are currently private APIs.
+See L</"USE OF INTERNAL APIS">.
 
 =head1 USE OF INTERNAL APIS
 

--- a/lib/Neo4j/Driver/PluginManager.pm
+++ b/lib/Neo4j/Driver/PluginManager.pm
@@ -8,7 +8,7 @@ package Neo4j::Driver::PluginManager;
 
 
 # This package is not part of the public Neo4j::Driver API.
-# (except as far as documented in Plugins.pod)
+# (except as far as documented in Plugin.pm)
 
 
 use Carp qw(croak);

--- a/lib/Neo4j/Driver/PluginManager.pm
+++ b/lib/Neo4j/Driver/PluginManager.pm
@@ -41,14 +41,14 @@ sub trigger_event {
 	
 	my $default_handler = $self->{default_handlers}->{$event};
 	my $handlers = $self->{handlers}->{$event}
-		or return $default_handler ? $default_handler->() : undef;
+		or return $default_handler ? $default_handler->() : ();
 	
-	my @callbacks;
+	my $callback = $default_handler // sub {};
 	for my $handler ( reverse @$handlers ) {
-		my $continue = $callbacks[$#callbacks] // $default_handler // sub {};
-		push @callbacks, sub { $handler->($continue, @params) };
+		my $continue = $callback;
+		$callback = sub { $handler->($continue, @params) };
 	}
-	return $callbacks[$#callbacks]->();
+	return $callback->();
 	
 	# Right now, ALL events get a continuation callback.
 	# But this will almost certainly change eventually.

--- a/lib/Neo4j/Driver/PluginManager.pm
+++ b/lib/Neo4j/Driver/PluginManager.pm
@@ -60,6 +60,7 @@ sub _register_plugin {
 	my ($self, $plugin) = @_;
 	
 	croak "Can't locate object method new() via package $plugin (perhaps you forgot to load \"$plugin\"?)" unless $plugin->can('new');
+	croak "Package $plugin is not a Neo4j::Driver::Plugin" unless $plugin->DOES('Neo4j::Driver::Plugin');
 	croak "Method register() not implemented by package $plugin (is this a Neo4j::Driver plug-in?)" unless $plugin->can('register');
 	
 	$plugin = $plugin->new if ref $plugin eq '';

--- a/lib/Neo4j/Driver/PluginManager.pm
+++ b/lib/Neo4j/Driver/PluginManager.pm
@@ -1,0 +1,67 @@
+use 5.010;
+use strict;
+use warnings;
+use utf8;
+
+package Neo4j::Driver::PluginManager;
+# ABSTRACT: Plug-in manager for Neo4j::Driver
+
+
+# This package is not part of the public Neo4j::Driver API.
+
+
+use Carp qw(croak);
+our @CARP_NOT = qw(Neo4j::Driver);
+
+
+sub new {
+	# uncoverable pod
+	my ($class) = @_;
+	
+	return bless {}, $class;
+}
+
+
+sub add_event_handler {
+	# uncoverable pod (see Plugins.pod)
+	my ($self, $event, $handler, @extra) = @_;
+	
+	croak "add_event_handler() with more than one handler unsupported" if @extra;
+	
+	push @{$self->{handlers}->{$event}}, $handler;
+}
+
+
+sub trigger_event {
+	# uncoverable pod (see Plugins.pod)
+	my ($self, $event, @params) = @_;
+	
+	my $default_handler = $self->{default_handlers}->{$event};
+	my $handlers = $self->{handlers}->{$event}
+		or $default_handler and return $default_handler->()
+		or return;
+	
+	my @callbacks;
+	for my $handler ( reverse @$handlers ) {
+		my $continue = $callbacks[$#callbacks] // $default_handler // sub {};
+		push @callbacks, sub { $handler->($continue, @params) };
+	}
+	return $callbacks[$#callbacks]->();
+	
+	# Right now, ALL events get a continuation callback.
+	# But this will almost certainly change eventually.
+}
+
+
+# Tell a new plugin to register itself using this manager.
+sub _register_plugin {
+	my ($self, $plugin) = @_;
+	
+	croak "Can't locate object method new() via package $plugin (perhaps you forgot to load \"$plugin\"?)" unless $plugin->can('new');
+	croak "Method register() not implemented by package $plugin (is this a Neo4j::Driver plug-in?)" unless $plugin->can('register');
+	
+	$plugin->new->register($self);
+}
+
+
+1;

--- a/lib/Neo4j/Driver/Plugins.pod
+++ b/lib/Neo4j/Driver/Plugins.pod
@@ -1,0 +1,202 @@
+# PODNAME: Neo4j::Driver::Plugins
+# ABSTRACT: Specification of the driver's plug-in interface
+
+=encoding utf8
+
+=head1 SYNPOSIS
+
+ package Local::MyNeo4jPlugin;
+ use feature 'signatures';
+ 
+ sub new ($class) { bless {}, $class }
+ 
+ sub register ($self, $manager, @) {
+   $manager->add_event_handler(
+     http_adapter_factory => sub {
+       Local::MyNeo4jLWPAdapter->new();
+     },
+   );
+ }
+ 
+ package Local::MyNeo4jLWPAdapter;
+ use parent 'Neo4j::Driver::Net::HTTP::LWP';
+ ...;
+ 
+ package main;
+ use Neo4j::Driver 0.31;
+ 
+ $driver = Neo4j::Driver->new();
+ $driver->plugin('Local::MyNeo4jPlugin');
+
+=head1 WARNING: EXPERIMENTAL
+
+Take great care when implementing plug-ins, because even small
+deviations from this specification may cause your code to break
+with future versions of the driver in non-obvious ways.
+
+Additionally, the design of the plug-in API is not finalised.
+You should probably let me know if you already are writing
+plug-ins, so that I can try to accommodate your use case
+and give you advance notice of changes.
+
+B<The entire plug-in API is currently highly experimental.>
+
+The driver's C<plugins()> method is
+L<experimental|Neo4j::Driver/"Plug-in modules"> as well.
+
+=head1 OVERVIEW
+
+Plug-ins can be used to extend and customise L<Neo4j::Driver>
+to a significant degree. Upon being loaded, a plug-in will be
+asked to register event handlers with the driver. Handlers
+are references to custom subroutines defined by the plug-in.
+They will be invoked when the event they were registered for
+is triggered.
+
+Events triggered by the driver are specified in this document;
+see L</"EVENTS"> below. Plug-ins can also define custom events.
+
+Event handlers may receive a code reference for continuing with
+the next handler registered for that event. When provided, this
+callback should be treated as the default driver action for that
+event. Depending on what a plug-in's purpose is, it may be useful
+to either invoke this callback and work with the results, or to
+ignore it entirely and handle the event independently.
+
+In some cases, handling an event or not handling an event can
+have side effects. In some cases, an event can only be handled a
+single time, with any additional handlers being ignored. In some
+cases, the return value of an event handler may be significant.
+All of these API details are still evolving.
+
+I'm grateful for any feedback you I<(yes, you!)> might have on
+this driver's plug-in API. Please open a GitHub issue or get in
+touch via email (make sure you mention Neo4j in the subject to
+beat the spam filters).
+
+I<The plug-in interface as described in this document is available
+since version 0.31.>
+
+=head1 EVENTS
+
+This version of L<Neo4j::Driver> can trigger the following events.
+Future versions may introduce new events or remove existing ones.
+
+=over
+
+=item http_adapter_factory
+
+ $manager->add_event_handler(
+   http_adapter_factory => sub ($continue, $driver, @) {
+     my $adapter;
+     ...
+     return $adapter // $continue->();
+   },
+ );
+
+This event is triggered when a new HTTP adapter instance is
+needed during session creation. Parameters given are a code
+reference for continuing with the next handler registered for
+this event, the driver, and an indeterminate number of extra
+arguments that are to be ignored.
+
+A handler for this event must return the blessed instance of
+an HTTP adapter module (formerly known as "networking module")
+to be used instead of the default adapter built into the driver.
+See L<Neo4j::Driver::Net/"API of an HTTP networking module">.
+
+=back
+
+More events may be added in future versions. If you have a need
+for a specific event, let me know and I'll see if I can add it
+easily.
+
+If your plug-in defines custom events of its own, it must only
+use event names that beginn with C<x_>. All other event names
+are reserved for use by the driver itself.
+
+Note that future versions of the driver may trigger events with
+different arguments based on their name. In particular, you
+should for the time being avoid using custom event names that
+start with C<x_after_> and C<x_before_>, but other event names
+may also be affected.
+
+=head1 METHODS
+
+The plug-in itself must implement the following methods.
+
+=over
+
+=item new
+
+ sub new ($class, @) { ... }
+
+Plug-in constructor. Returns a blessed reference. Parameters
+given are the plug-in package name and an indeterminate number
+of extra arguments that are to be ignored.
+
+=item register
+
+ sub register ($self, $manager, @) { ... }
+
+Called by the driver when a plug-in is loaded. Parameters given
+are the plug-in, a plug-in manager, and an indeterminate number of
+extra arguments that are to be ignored.
+
+This method is expected to attach this plug-in's event handlers
+by calling the plug-in manager's L</"add_event_handler"> method.
+See L</"EVENTS"> for a list of events supported by this version
+of the driver.
+
+=back
+
+=head1 THE PLUG-IN MANAGER
+
+The job of the plug-in manager is to invoke the appropriate
+event handlers when events are triggered. It also allows clients
+to modify the list of registered handlers. A reference to the
+plug-in manager is provided to your plug-in when it is loaded;
+see L</"register">.
+
+The plug-in manager implements the following methods.
+
+=over
+
+=item add_event_handler
+
+ $manager->add_event_handler( event_name => sub {
+   ...
+ });
+
+Registers the given handler for the named event. When that event
+is triggered, the handler will be invoked (unless another plug-in's
+handler for the same event prevents this). Handlers will not be
+invoked in any particular defined order.
+
+If you use signatures, take care to specify the correct arity for
+your handlers. Future updates to the driver may change existing
+events to provide more parameters. The correct way to specify the
+signature of an event handler is to end it with C<@>.
+
+=item trigger_event
+
+ $manager->trigger_event( 'event_name', @parameters );
+
+Called by the driver to trigger an event and invoke any registered
+handlers for it. May be given an arbitrary number of parameters,
+all of which will be passed through to the event handler.
+
+Most plug-ins won't need to call this method. But plug-ins may
+choose to trigger and handle custom events. These must have names
+that begin with C<x_>. Plug-ins should not trigger events with
+other names, as these are reserved for internal use by the driver
+itself.
+
+Events that are triggered, but not handled, are currently silently
+ignored. This will likely change in a future version of the driver.
+
+Calling this method in list context is discouraged, because doing
+so might be treated specially by a future version of the driver.
+Use C<scalar> to be safe.
+
+=back

--- a/lib/Neo4j/Driver/Transaction.pm
+++ b/lib/Neo4j/Driver/Transaction.pm
@@ -464,7 +464,7 @@ This feature might eventually be used to implement lazy statement
 execution for this driver. The private C<_run_multiple()> method
 which makes using this feature explicit is expected to remain
 available at least until that time. See also
-L<Neo4j::Driver::Net/"USE OF INTERNAL APIS">.
+L<Neo4j::Driver::Plugin/"USE OF INTERNAL APIS">.
 
 =head1 SEE ALSO
 

--- a/t/bolt.t
+++ b/t/bolt.t
@@ -72,7 +72,7 @@ use Neo4j::Driver;
 
 sub new_session {
 	my $d = Neo4j::Driver->new('bolt:');
-	$d->config(net_module => shift);
+	$d->{net_module} = shift;
 	$d->basic_auth(username => 'password');
 	$d->{tls} = shift if scalar @_;
 	$d->{auth} = shift if scalar @_;

--- a/t/config.t
+++ b/t/config.t
@@ -101,8 +101,7 @@ subtest 'config illegal args' => sub {
 
 subtest 'config/session sequence' => sub {
 	plan tests => 8;
-	my $config = {net_module => 'Neo4j_Test::MockHTTP'};
-	lives_ok { $d = 0; $d = Neo4j::Driver->new($config) } 'new mock driver';
+	lives_ok { $d = 0; $d = Neo4j::Driver->new->plugin('Neo4j_Test::MockHTTP') } 'new mock driver';
 	lives_ok { $d->basic_auth(user => 'pw') } 'basic_auth before session';
 	lives_ok { $d->config(auth => undef) } 'config before session';
 	lives_ok { $d->session(database => 'dummy') } 'first session';
@@ -322,16 +321,16 @@ subtest 'cypher params' => sub {
 	lives_ok { $r = 0; $r = $t->_prepare(@q); } 'prepare unfiltered';
 	is $r->{statement}, 'RETURN {a}', 'unfiltered';
 	# verify that filter flag is automatically cleared for Neo4j 2
-	my $config = {cypher_params => v2, net_module => 'Neo4j_Test::MockHTTP'};
+	my $config = {cypher_params => v2};
 	my $d;
-	lives_ok { $d = Neo4j::Driver->new($config) } 'Neo4j 4: set filter mock';
+	lives_ok { $d = Neo4j::Driver->new($config)->plugin('Neo4j_Test::MockHTTP') } 'Neo4j 4: set filter mock';
 	lives_and { ok !! $d->session(database => 'dummy')->{cypher_params_v2} } 'Neo4j 4: filter';
-	lives_ok { $d = Neo4j::Driver->new($config) } 'Neo4j 2: set filter mock';
+	lives_ok { $d = Neo4j::Driver->new($config)->plugin('Neo4j_Test::MockHTTP') } 'Neo4j 2: set filter mock';
 	$Neo4j_Test::MockHTTP::res[0]->{json}{neo4j_version} = '2.3.12';
 	$Neo4j_Test::MockHTTP::res[0]->{content} = undef;
 	lives_and { ok !  $d->session(database => 'dummy')->{cypher_params_v2} } 'Neo4j 2: no filter';
 	$d = Neo4j::Driver->new('http:');
-	lives_ok { $d = Neo4j::Driver->new($config) } 'Sim: set filter mock';
+	lives_ok { $d = Neo4j::Driver->new($config)->plugin('Neo4j_Test::MockHTTP') } 'Sim: set filter mock';
 	$Neo4j_Test::MockHTTP::res[0]->{json}{neo4j_version} = '0.0.0';
 	$Neo4j_Test::MockHTTP::res[0]->{content} = undef;
 	lives_and { ok !! $d->session(database => 'dummy')->{cypher_params_v2} } 'Sim (0.0.0): filter';
@@ -343,7 +342,7 @@ subtest 'cypher params' => sub {
 subtest 'session config' => sub {
 	plan tests => 6;
 	my $d = Neo4j::Driver->new('http:');
-	lives_ok { $d->config(net_module => 'Neo4j_Test::MockHTTP') } 'set mock';
+	lives_ok { $d->plugin('Neo4j_Test::MockHTTP') } 'set mock';
 	my %db = (database => 'foobar');
 	lives_and { like $d->session( %db)->{net}{endpoints}{new_commit}, qr/\bfoobar\b/ } 'session hash';
 	lives_and { like $d->session(\%db)->{net}{endpoints}{new_commit}, qr/\bfoobar\b/ } 'session hash ref';

--- a/t/deprecated.t
+++ b/t/deprecated.t
@@ -172,7 +172,9 @@ subtest 'net_module config option' => sub {
 	lives_ok { $w = ''; $w = warning { $d->config(net_module => 'Neo4j_Test::Sim'); }; } 'config 1 lives';
 	like $w, qr/\bnet_module\b.*\bdeprecated\b/i, 'net_module 1 deprecated'
 		or diag 'got warning(s): ', explain $w;
+	SKIP: { skip 'test design requires Sim', 1 unless $Neo4j_Test::sim;
 	lives_ok { @w = (); @w = warnings { $d->session }; } 'session 1 lives';
+	}
 	lives_ok { $d = 0; $d = Neo4j::Driver->new(); } 'new driver 2';
 	lives_ok { $w = ''; $w = warning { $d->config(net_module => 'Neo4j_Test::NoSuchModule_'); }; } 'config 2 lives';
 	like $w, qr/\bnet_module\b.*\bdeprecated\b/i, 'net_module 2 deprecated'

--- a/t/experimental.t
+++ b/t/experimental.t
@@ -24,6 +24,8 @@ use Test::More 0.96 tests => 8 + 1;
 use Test::Exception;
 use Test::Warnings qw(warnings);
 
+use Neo4j_Test::MockHTTP qw(response_for);
+
 use Neo4j::Driver;
 
 
@@ -31,9 +33,6 @@ my ($q, $r, @a, $a);
 
 
 {
-package Neo4j_Test::Result::Keys;
-use parent 'Neo4j_Test::MockHTTP';
-sub response_for { &Neo4j_Test::MockHTTP::response_for }
 no warnings 'qw';
 response_for 'no keys' => { jolt => [qw(
 	{"header":{}} {"summary":{}} {"info":{}}
@@ -48,7 +47,7 @@ response_for 'three keys' => { jolt => [qw(
 subtest 'result keys() wantarray' => sub {
 	plan tests => 1 + 3*3;
 	my $d = Neo4j::Driver->new('http:');
-	$d->config(net_module => 'Neo4j_Test::Result::Keys');
+	$d->plugin('Neo4j_Test::MockHTTP');
 	my $sx;
 	lives_and { ok $sx = $d->session(database => 'dummy') } 'session';
 	lives_and { $r = 0; ok $r = $sx->run('no keys') } 'run 0';
@@ -64,9 +63,6 @@ subtest 'result keys() wantarray' => sub {
 
 
 {
-package Neo4j_Test::Summary::Notifications;
-use parent 'Neo4j_Test::MockHTTP';
-sub response_for { &Neo4j_Test::MockHTTP::response_for }
 no warnings 'qw';
 response_for 'zero notes' => { jolt => [qw(
 	{"header":{}} {"summary":{"stats":{}}} {"info":{}}
@@ -81,7 +77,7 @@ response_for 'two notes' => { jolt => [qw(
 subtest 'summary notifications() wantarray' => sub {
 	plan tests => 1 + 3*3;
 	my $d = Neo4j::Driver->new('http:');
-	$d->config(net_module => 'Neo4j_Test::Summary::Notifications');
+	$d->plugin('Neo4j_Test::MockHTTP');
 	my $sx;
 	lives_and { ok $sx = $d->session(database => 'dummy') } 'session';
 	lives_and { $r = 0; ok $r = $sx->run('zero notes')->summary } 'run 0';
@@ -96,10 +92,6 @@ subtest 'summary notifications() wantarray' => sub {
 };
 
 
-{
-package Neo4j_Test::Types::Context;
-use parent 'Neo4j_Test::MockHTTP';
-sub response_for { &Neo4j_Test::MockHTTP::response_for }
 sub single_column {[
 	{ header => { fields => [0] } },
 	(map {{ data => [$_] }} @_),
@@ -139,11 +131,10 @@ response_for 'path two' => { jolt => single_column( { '..' => [
 	{ '->' => [ 8, 7, 'TEST', 9, {} ] },
 	{ '()' => [ 9, [], {} ] },
 ]})};
-}
 subtest 'types node/path wantarray' => sub {
 	plan tests => 1 + 4*3 + 3*7;
 	my $d = Neo4j::Driver->new('http:');
-	$d->config(net_module => 'Neo4j_Test::Types::Context');
+	$d->plugin('Neo4j_Test::MockHTTP');
 	my $sx;
 	lives_and { ok $sx = $d->session(database => 'dummy') } 'session';
 	

--- a/t/info.t
+++ b/t/info.t
@@ -51,15 +51,14 @@ subtest 'partial' => sub {
 subtest 'default database' => sub {
 	plan tests => 3 + 3 + 10;
 	my ($d, $s, $si, $db);
-	my $config = { uri => 'http:', net_module => 'Neo4j_Test::MockHTTP' };
 	
-	lives_ok { $d = 0; $d = Neo4j::Driver->new($config) } 'driver 1';
+	lives_ok { $d = 0; $d = Neo4j::Driver->new('http:')->plugin('Neo4j_Test::MockHTTP') } 'driver 1';
 	lives_ok { $si = 0; $si = $d->session(database => 'dummy')->server } 'ServerInfo 1';
 	throws_ok { $si->_default_database($d) } qr/\bdefault database\b/i, 'default database failed';
 	
 	$Neo4j_Test::MockHTTP::res[0]->{json}{neo4j_version} = '3.5.0';
 	$Neo4j_Test::MockHTTP::res[0]->{content} = undef;
-	lives_ok { $d = 0; $d = Neo4j::Driver->new($config) } 'driver 2';
+	lives_ok { $d = 0; $d = Neo4j::Driver->new('http:')->plugin('Neo4j_Test::MockHTTP') } 'driver 2';
 	lives_ok { $si = 0; $si = $d->session->server } 'ServerInfo 2';
 	lives_and { is $si->_default_database($d), undef } 'no default database';
 	$Neo4j_Test::MockHTTP::res[0]->{json}{neo4j_version} = '4.2.5';
@@ -71,7 +70,7 @@ subtest 'default database' => sub {
 		{ summary => {} },
 		{ info => {} },
 	]};
-	lives_ok { $d = 0; $d = Neo4j::Driver->new($config) } 'driver 3';
+	lives_ok { $d = 0; $d = Neo4j::Driver->new('http:')->plugin('Neo4j_Test::MockHTTP') } 'driver 3';
 	lives_ok { $si = 0; $si = $d->session(database => 'dummy')->server } 'ServerInfo 3';
 	isa_ok $si, 'Neo4j::Driver::ServerInfo', 'ServerInfo type';
 	is $si->{default_database}, undef, 'default database not cached';

--- a/t/jolt-types.t
+++ b/t/jolt-types.t
@@ -7,11 +7,7 @@ use Test::More 0.88;
 use Test::Exception;
 use Test::Warnings;
 
-{
-
-package Neo4j_Test::JoltTypes;
-use parent 'Neo4j_Test::MockHTTP';
-sub response_for { &Neo4j_Test::MockHTTP::response_for }
+use Neo4j_Test::MockHTTP qw(response_for);
 
 sub single_column {[
 	{ header => { fields => [0] } },
@@ -75,8 +71,6 @@ response_for 'sigil error' => { jolt => single_column(
 	{ '' => '' },
 )};
 
-}
-
 
 # Confirm that the deep_bless Jolt parser correctly
 # converts Neo4j values to Perl values.
@@ -89,7 +83,7 @@ plan tests => 1 + 6 + 1;
 
 
 lives_and { ok $s = Neo4j::Driver->new('http:')
-                    ->config(net_module => 'Neo4j_Test::JoltTypes')
+                    ->plugin('Neo4j_Test::MockHTTP')
                     ->session(database => 'dummy') } 'session';
 
 

--- a/t/lib/Neo4j_Test/MockHTTP.pm
+++ b/t/lib/Neo4j_Test/MockHTTP.pm
@@ -2,12 +2,29 @@ use strict;
 use warnings;
 package Neo4j_Test::MockHTTP;
 
+use parent 'Neo4j::Driver::Plugin';
+use parent 'Exporter';
+
+our @EXPORT_OK = qw(response_for);
+
 use JSON::MaybeXS;
 use Neo4j::Driver::Net::HTTP::LWP;
 
 sub new {
-	my ($class, $driver) = @_;
-	bless { base => $driver->{uri} }, $class;
+	my ($class) = @_;
+	bless {}, $class;
+}
+
+sub register {
+	my ($self, $manager) = @_;
+	
+	$manager->add_event_handler(
+		http_adapter_factory => sub {
+			my ($continue, $driver) = @_;
+			$self->{base} = $driver->{uri};
+			return $self;
+		},
+	);
 }
 
 my $coder = JSON::MaybeXS->new(utf8 => 1, allow_nonref => 1);

--- a/t/lib/Neo4j_Test/NetModulePlugin.pm
+++ b/t/lib/Neo4j_Test/NetModulePlugin.pm
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+package Neo4j_Test::NetModulePlugin;
+
+use parent 'Neo4j::Driver::Plugin';
+
+sub new {
+	my ($class, $net_module) = @_;
+	bless \$net_module, $class;
+}
+
+sub register {
+	my ($self, $manager) = @_;
+	my $net_module = $$self;
+	
+	$manager->add_event_handler(
+		http_adapter_factory => sub {
+			my ($continue, $driver) = @_;
+			return $net_module->new($driver);
+		},
+	);
+}
+
+
+1;
+
+__END__
+
+This is a tiny wrapper that basically simulates the old net_module
+config option using the new plug-in API. It can be used like this:
+
+my $net_module = 'Local::MyOldNetModule';
+$driver->plugin( Neo4j_Test::NetModulePlugin->new($net_module) );

--- a/t/net-lwp.t
+++ b/t/net-lwp.t
@@ -39,7 +39,7 @@ lives_ok { $m = Neo4j::Driver::Net::HTTP::LWP->new($driver) } 'new';
 subtest 'static' => sub {
 	plan tests => 5;
 	lives_and { like $m->uri(), qr/\Q$uri\E/i } 'uri';
-	lives_and { is_deeply [$m->result_handlers], [] } 'result_handlers';
+	is_deeply [eval { $m->result_handlers }], [], 'result_handlers';
 	my $coder;
 	lives_ok { $coder = $m->json_coder } 'json_coder lives';
 	lives_and { ok $coder->can('decode') } 'json_coder';

--- a/t/plugins.t
+++ b/t/plugins.t
@@ -1,0 +1,238 @@
+#!perl
+use strict;
+use warnings;
+use lib qw(./lib t/lib);
+
+use Test::More 0.88;
+use Test::Exception;
+use Test::Warnings qw(warning);
+
+
+# Unit tests for Neo4j::Driver::PluginManager
+
+plan tests => 9 + 1;
+
+use Neo4j::Driver;
+use Neo4j::Driver::PluginManager;
+
+
+my ($m, $p);
+
+
+subtest 'new' => sub {
+	plan tests => 2;
+	lives_and { ok $m = Neo4j::Driver::PluginManager->new() } 'new';
+	isa_ok $m, Neo4j::Driver::PluginManager::, 'PluginManager';
+};
+
+
+{
+	package Neo4j_Test::Plugin::NoNew;
+	use parent 'Neo4j::Driver::Plugin';
+	sub register { die }
+	
+	package Neo4j_Test::Plugin::NoRegister;
+	use parent 'Neo4j::Driver::Plugin';
+	sub new { bless [], shift }
+	
+	package Neo4j_Test::Plugin::RegisterFoo;
+	use parent 'Neo4j::Driver::Plugin';
+	sub new { bless [], shift }
+	sub register {
+		my ($self, $manager) = @_;
+		die unless $manager->isa( Neo4j::Driver::PluginManager:: );
+		$manager->{_foo} = 'foo';
+	}
+}
+
+
+subtest 'register' => sub {
+	plan tests => 8;
+	lives_and { ok $m = Neo4j::Driver::PluginManager->new() } 'new';
+	throws_ok { $m->_register_plugin( Neo4j_Test::Plugin::NoNew:: ) }
+		qr/\bCan't locate\b.*\bmethod new\b.*\bNeo4j_Test::Plugin::NoNew\b/i, 'no new';
+	throws_ok { $m->_register_plugin( Neo4j_Test::Plugin::NoRegister:: ) }
+		qr/\bMethod register\b.*\bnot implemented\b.*\bNeo4j_Test::Plugin::NoRegister\b/i, 'no register';
+	lives_ok { $m->_register_plugin( Neo4j_Test::Plugin::RegisterFoo:: ) } 'register foo';
+	is $m->{_foo}, 'foo', 'register set _foo';
+	lives_and { ok $m = Neo4j::Driver::PluginManager->new() } 'new 2';
+	lives_ok { $m->_register_plugin( Neo4j_Test::Plugin::RegisterFoo->new ) } 'register foo 2';
+	is $m->{_foo}, 'foo', 'register set _foo 2';
+};
+
+
+{
+	package Neo4j_Test::Plugin::SimpleReturns;
+	use parent 'Neo4j::Driver::Plugin';
+	sub new { bless [], shift }
+	sub register {
+		my ($self, $manager) = @_;
+		$manager->add_event_handler( foo => sub { 'foofoo' } );
+		$manager->add_event_handler( foo => sub { 'foobar' } );
+		$manager->add_event_handler( x_foo => sub { 'bar' } );
+		$manager->add_event_handler( empty => sub {} );
+		my $push = sub { push @$self, 1 };  # yields array length after push
+		$manager->add_event_handler( single => $push );
+		$manager->add_event_handler( single => $push );
+		# the first arg to a handler is always the $continue code ref, which we ignore here
+		$manager->add_event_handler( first_arg => sub { shift; shift } );
+		$manager->add_event_handler( all_args => sub { shift; \@_ } );
+	}
+}
+
+
+subtest 'simple returns' => sub {
+	plan tests => 14;
+	lives_and { ok $m = Neo4j::Driver::PluginManager->new() } 'new';
+	lives_ok { $m->_register_plugin( Neo4j_Test::Plugin::SimpleReturns:: ) } 'register';
+	lives_and { is $m->trigger_event('x_foo'), 'bar' } 'x_foo';
+	lives_and { like $m->trigger_event('foo'), qr/^foofoo$|^foobar$/ } 'foo';
+	lives_and { is $m->trigger_event('empty'), undef } 'empty';
+	is scalar(@{$m->{handlers}{single}}), 2, 'registered two handlers for single';
+	lives_and { is $m->trigger_event('single'), 1 } 'single 1';
+	lives_and { is $m->trigger_event('single'), 2 } 'only one handler was executed for single 1';
+	lives_and { is $m->trigger_event('first_arg'), undef } 'first_arg undef';
+	lives_and { is $m->trigger_event('first_arg', 0), 0 } 'first_arg 0';
+	lives_and { is $m->trigger_event('first_arg', 1..4), 1 } 'first_arg 1';
+	lives_and { is_deeply $m->trigger_event('all_args'), [] } 'args []';
+	lives_and { is_deeply $m->trigger_event('all_args', 0), [0] } 'args [0]';
+	lives_and { is_deeply $m->trigger_event('all_args', 1..4), [1..4] } 'args [1..4]';
+};
+
+
+{
+	package Neo4j_Test::Plugin::Countdown;
+	use parent 'Neo4j::Driver::Plugin';
+	sub new { bless [], shift }
+	sub register {
+		my ($self, $manager) = @_;
+		$manager->add_event_handler( x_countdown => sub {
+			my ($continue, $count) = @_;
+			return [0] if $count <= 0;
+			my $more = $manager->trigger_event('x_countdown', $count - 1);
+			return [$count, @$more];
+		});
+	}
+}
+
+
+subtest 'custom event recursive countdown' => sub {
+	plan tests => 3;
+	lives_and { ok $m = Neo4j::Driver::PluginManager->new() } 'new';
+	lives_ok { $m->_register_plugin( Neo4j_Test::Plugin::Countdown:: ) } 'register';
+	lives_and { is_deeply $m->trigger_event('x_countdown', 10), [reverse 0..10] } 'countdown 10';
+};
+
+
+{
+	package Neo4j_Test::Plugin::MultiHandler;
+	use parent 'Neo4j::Driver::Plugin';
+	sub new { bless [0, 0], shift }
+	sub register {
+		my ($self, $manager) = @_;
+		$manager->add_event_handler( plugin_ref => sub { $self } );
+		$manager->add_event_handler( once => sub { $self->[0]++; shift->() } );
+		$manager->add_event_handler( thrice => sub { $self->[1] += 1; shift->() } );
+		$manager->add_event_handler( thrice => sub { $self->[1] += 2; shift->() } );
+		$manager->add_event_handler( thrice => sub { $self->[1] += 4; shift->() } );
+		$manager->add_event_handler( retval => sub { my $x = shift->() // 0; $x + 1 } );
+		$manager->add_event_handler( retval => sub { my $x = shift->() // 0; $x + 2 } );
+	}
+}
+
+
+subtest 'multiple handlers for an event' => sub {
+	plan tests => 8;
+	lives_and { ok $m = Neo4j::Driver::PluginManager->new() } 'new';
+	lives_ok { $m->_register_plugin( Neo4j_Test::Plugin::MultiHandler:: ) } 'register';
+	lives_and { ok $p = $m->trigger_event('plugin_ref') } 'plugin_ref';
+	lives_and { is $m->trigger_event('once'), undef } 'fallthrough once undef';
+	lives_and { is $m->trigger_event('thrice'), undef } 'fallthrough thrice undef';
+	is $p->[0], 1, '1 once';
+	is $p->[1], 7, '3 thrice';
+	lives_and { is $m->trigger_event('retval'), 3 } 'return values';
+};
+
+
+{
+	package Neo4j_Test::Plugin::DefaultHandler;
+	use parent 'Neo4j::Driver::Plugin';
+	sub new { bless [], shift }
+	sub register {
+		my ($self, $manager) = @_;
+		$manager->add_event_handler( 1 => sub { shift->() . 'one' } );
+		$manager->add_event_handler( 2 => sub { shift->() . 'two' } );
+		$manager->add_event_handler( 2 => sub { shift->() . 'two' } );
+		$manager->add_event_handler( 8 => sub { shift->() . 'eight' } );
+	}
+}
+
+
+subtest 'default handlers' => sub {
+	plan tests => 10;
+	lives_and { ok $m = Neo4j::Driver::PluginManager->new() } 'new';
+	lives_ok { $m->{default_handlers}->{0} = sub { 'nada' } } 'add default handler zero';
+	lives_ok { $m->{default_handlers}->{1} = sub { 'una' } } 'add default handler one';
+	lives_ok { $m->{default_handlers}->{2} = sub { 'bisso' } } 'add default handler two';
+	lives_ok { $m->_register_plugin( Neo4j_Test::Plugin::DefaultHandler:: ) } 'register';
+	lives_ok { $m->{default_handlers}->{8} = sub { 'okto' } } 'add default handler eight';
+	lives_and { is $m->trigger_event(0), 'nada' } 'zero default handler';
+	lives_and { is $m->trigger_event(1), 'unaone' } 'one';
+	lives_and { is $m->trigger_event(2), 'bissotwotwo' } 'two';
+	lives_and { is $m->trigger_event(8), 'oktoeight' } 'eight';
+};
+
+
+subtest 'trigger unhandled' => sub {
+	plan tests => 10;
+	lives_and { ok $m = Neo4j::Driver::PluginManager->new() } 'new';
+	lives_ok { $m->trigger_event( 'foo' ) } 'unhandled lives';
+	lives_ok { $m->trigger_event( 'foo', 'bar' ) } 'unhandled w/ param lives';
+	lives_ok { $m->trigger_event( 'x_foo' ) } 'unhandled x lives';
+	lives_ok { scalar $m->trigger_event( 'bar' ) } 'unhandled scalar lives';
+	lives_ok { ( $m->trigger_event( 'bar' ) ) } 'unhandled list lives';
+	lives_ok { $m->add_event_handler( 'foobar' => sub { 'xxx' } ) } 'add_event_handler';
+	lives_and { is $m->trigger_event( 'foo' ), undef } 'shorter is unhandled';
+	lives_and { is $m->trigger_event( 'foobar ' ), undef } 'longer is unhandled';
+	lives_and { is $m->trigger_event( 'foobar' ), 'xxx' } 'late added handler';
+};
+
+
+subtest 'errors' => sub {
+	plan tests => 10;
+	lives_and { ok $m = Neo4j::Driver::PluginManager->new() } 'new';
+	throws_ok { $m->add_event_handler( event => sub {}, event2 => sub {} ) }
+		qr/\badd_event_handler\b.*\bmore than one\b.*\bunsupported\b/i, 'two events';
+	throws_ok { $m->add_event_handler( event => sub {}, sub {} ) }
+		qr/\badd_event_handler\b.*\bmore than one\b.*\bunsupported\b/i, 'odd number of args';
+	throws_ok { $m->add_event_handler( event => 'sub_name' ) }
+		qr/\bhandler\b.*\bmust be\b.*\bsubroutine reference\b/i, 'handler by sub name';
+	throws_ok { $m->add_event_handler( event => [] ) }
+		qr/\bhandler\b.*\bmust be\b.*\bsubroutine reference\b/i, 'array as handler';
+	throws_ok { $m->add_event_handler( 'event' ) }
+		qr/\bhandler\b.*\bmust be\b.*\bsubroutine reference\b/i, 'no handler';
+	throws_ok { $m->add_event_handler( undef, sub {} ) }
+		qr/\bEvent name\b.*defined\b/i, 'no event name';
+	throws_ok { $m->_register_plugin( 'Neo4j::Driver' ) }
+		qr/\bnot\b.*\bNeo4j::Driver::Plugin\b/i, 'register non-plugin package';
+	throws_ok { $m->_register_plugin( Neo4j::Driver->new ) }
+		qr/\bnot\b.*\bNeo4j::Driver::Plugin\b/i, 'register non-plugin object';
+	dies_ok { $m->_register_plugin( undef ) } 'register undef';
+};
+
+
+subtest 'register via driver' => sub {
+	my $d;
+	plan skip_all => '(driver constructor failed)' unless eval { $d = Neo4j::Driver->new };
+	plan tests => 5;
+	lives_ok { $d->plugin( 'Neo4j_Test::Plugin::RegisterFoo' ) } 'plugin with package';
+	is $d->{plugins}->{_foo}, 'foo', 'package set _foo';
+	throws_ok { $d->plugin( 'Neo4j_Test::Plugin::RegisterFoo', 1 ) }
+		qr/\bplugin\b.*\bmore than one argument\b.*\bunsupported\b/i, 'extra';
+	$d->{plugins}->{_foo} = '';
+	lives_ok { $d->plugin( Neo4j_Test::Plugin::RegisterFoo->new ) } 'plugin with instance';
+	is $d->{plugins}->{_foo}, 'foo', 'instance set _foo';
+};
+
+
+done_testing;


### PR DESCRIPTION
The [`net_module` config option](https://metacpan.org/release/AJNN/Neo4j-Driver-0.21/view/lib/Neo4j/Driver.pm#Custom-networking-modules) already offers clients a great deal of flexibility, but its API is brittle due to tight coupling and it’s difficult to extend its capabilities beyond what is offered now. Even within those limits, you often end up having to duplicate lots of existing code. A more generic plug-in API would help resolve these issues. It could be added in the following steps:

0. Document the design of the plug-in API itself. ✅ – see [Plugin.pm](https://github.com/johannessen/neo4j-driver-perl/blob/857d1b26830a52ed4c507f47a8c4dd3fe3bd880c/lib/Neo4j/Driver/Plugin.pm)
1. Implement the plug-in API far enough to make the `net_module` option redundant. ✅
2. Convert test suite, simulator etc. to plug-ins. ✅
3. Update the documentation across the driver to refer to plug-ins instead of the `net_module` option. Also update [Neo4j::Driver::Net](https://metacpan.org/pod/release/AJNN/Neo4j-Driver-0.21/lib/Neo4j/Driver/Net.pod) as required, including how to convert existing code to plug-ins. ✅
4. Remove or deprecate the `net_module` option. ✅

- - -

That’s how far _this_ PR is intended to take it. Probably also good enough for the eventual release of version 1.00 of the driver. Past that, the following “stretch goals” are conceivable:

5. Offer a few selected additional events for plug-ins to hook into. There are some obvious low-hanging fruits that can vastly extend the driver’s flexibility. For example, an event triggered during URI parsing could be used to implement support for the `neo4j:` URI scheme in a plug-in. Events during the `deep_bless` operation in the result handlers could be used to modify the result format to your needs. Also, exception events could make proper error handling easier (related to [#7](https://github.com/johannessen/neo4j-driver-perl/issues/7)).

6. In the long run, it might _perhaps_ be nice to offer events not just whereever they're easy to add in an opportunistic fashion, but to have a complete set of events triggered at strategic points throughout the driver. Ideally, _all_ parts of the software’s implementation should be swappable or controllable through plug-ins. In fact, many if not most parts of the driver itself theoretically _could_ be implemented as individual plug-ins. This would however likely require a quite careful redesign of the driver, and I’m thinking [YAGNI](https://wiki.c2.com/?YouArentGonnaNeedIt). (But do tell me if you feel this would be useful.)

The entire plug-in API is to be considered **experimental** until further notice (as noted in the docs).
