### PR TITLE
Deprecate old aliases of methods/options that were renamed by Neo4j

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,9 @@
 Revision history for Neo4j::Driver
 
-1.0051  2024-11-23  (TRIAL RELEASE)
+1.0052  2024-11-23  (TRIAL RELEASE)
 
  - Deprecate config options tls/tls_ca in favour of encrypted/trust_ca
+ - Deprecate ServerInfo->version() in favour of agent()
 
 1.00  2024-11-21  (TRIAL RELEASE)
 

--- a/Changes
+++ b/Changes
@@ -1,9 +1,10 @@
 Revision history for Neo4j::Driver
 
-1.0052  2024-11-23  (TRIAL RELEASE)
+1.0053  2024-11-24  (TRIAL RELEASE)
 
  - Deprecate config options tls/tls_ca in favour of encrypted/trust_ca
  - Deprecate ServerInfo->version() in favour of agent()
+ - Deprecate ResultSummary->statement() in favour of query()
 
 1.00  2024-11-21  (TRIAL RELEASE)
 

--- a/Changes
+++ b/Changes
@@ -1,10 +1,11 @@
 Revision history for Neo4j::Driver
 
-1.0053  2024-11-24  (TRIAL RELEASE)
+1.0054  2024-11-24  (TRIAL RELEASE)
 
  - Deprecate config options tls/tls_ca in favour of encrypted/trust_ca
  - Deprecate ServerInfo->version() in favour of agent()
  - Deprecate ResultSummary->statement() in favour of query()
+ - Deprecate Result->summary() in favour of consume()
 
 1.00  2024-11-21  (TRIAL RELEASE)
 

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Neo4j::Driver
 
+1.0051  2024-11-23  (TRIAL RELEASE)
+
+ - Deprecate config options tls/tls_ca in favour of encrypted/trust_ca
+
 1.00  2024-11-21  (TRIAL RELEASE)
 
  - Disallow all deprecated features.

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2016-2024
 
-version = 1.0052
+version = 1.0053
 release_status = unstable
 
 [Meta::Contributors]

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2016-2024
 
-version = 1.0053
+version = 1.0054
 release_status = unstable
 
 [Meta::Contributors]

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2016-2024
 
-version = 1.0051
+version = 1.0052
 release_status = unstable
 
 [Meta::Contributors]

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2016-2024
 
-version = 1.00
+version = 1.0051
 release_status = unstable
 
 [Meta::Contributors]

--- a/lib/Neo4j/Driver.pm
+++ b/lib/Neo4j/Driver.pm
@@ -28,13 +28,13 @@ my %NEO4J_DEFAULT_PORT = (
 my %OPTIONS = (
 	auth => 'auth',
 	cypher_params => 'cypher_params_v2',
-	encrypted => 'tls',
 	concurrent_tx => 'concurrent_tx',
+	encrypted => 'encrypted',
 	max_transaction_retry_time => 'max_transaction_retry_time',
 	timeout => 'timeout',
-	tls => 'tls',
-	tls_ca => 'tls_ca',
-	trust_ca => 'tls_ca',
+	tls => 'encrypted',
+	tls_ca => 'trust_ca',
+	trust_ca => 'trust_ca',
 	uri => 'uri',
 );
 
@@ -105,7 +105,7 @@ sub _fix_neo4j_uri {
 	croak "The concurrent_tx config option may only be used with http:/https: URIs" if $self->{config}->{concurrent_tx};
 	
 	my $uri = $self->{config}->{uri};
-	$uri->scheme( exists $INC{'Neo4j/Bolt.pm'} ? 'bolt' : $self->{config}->{tls} ? 'https' : 'http' );
+	$uri->scheme( exists $INC{'Neo4j/Bolt.pm'} ? 'bolt' : $self->{config}->{encrypted} ? 'https' : 'http' );
 	$uri->port( $NEO4J_DEFAULT_PORT{ $uri->scheme } ) if ! $uri->_port;
 }
 
@@ -173,6 +173,9 @@ sub _parse_options {
 	
 	croak "Odd number of elements in $context options hash" if @options & 1;
 	my %options = @options;
+	
+	warnings::warnif deprecated => "Config option tls is deprecated; use encrypted" if $options{tls};
+	warnings::warnif deprecated => "Config option tls_ca is deprecated; use trust_ca" if $options{tls_ca};
 	
 	if ($options{cypher_params}) {
 		croak "Unimplemented cypher params filter '$options{cypher_params}'" if $options{cypher_params} !~ m<^\x02|v2$>;

--- a/lib/Neo4j/Driver/Config.pod
+++ b/lib/Neo4j/Driver/Config.pod
@@ -126,8 +126,8 @@ This option is only useful for Bolt connections. For HTTP
 connections, the use of TLS encryption is governed by the chosen
 URI scheme (C<http> / C<https>).
 
-Before version 0.27, this option was named C<tls>. Use of the
-former name is now discouraged.
+Before version 0.27, this option was named C<tls>. That name has since
+been deprecated, matching a corresponding change in S<Neo4j 3.2>.
 
 =head2 max_transaction_retry_time
 
@@ -164,8 +164,8 @@ the certificates in this file (or by an intermediary).
 Self-signed certificates (such as those automatically provided by
 some Neo4j versions) should also work if their S<"CA bit"> is set.
 
-Before version 0.27, this option was named C<tls_ca>. Use of the
-former name is now discouraged.
+Before version 0.27, this option was named C<tls_ca>. That name has
+since been deprecated, as it didn't match Neo4j terminology.
 
 =head2 uri
 

--- a/lib/Neo4j/Driver/Record.pm
+++ b/lib/Neo4j/Driver/Record.pm
@@ -67,7 +67,9 @@ sub data {
 
 
 sub summary {
+	# uncoverable pod (see consume)
 	my ($self) = @_;
+	warnings::warnif deprecated => "summary() in Neo4j::Driver::Record is deprecated; use consume() in Neo4j::Driver::Result instead";
 	
 	$self->{_summary} //= Neo4j::Driver::ResultSummary->new;
 	return $self->{_summary}->_init;

--- a/lib/Neo4j/Driver/Record.pm
+++ b/lib/Neo4j/Driver/Record.pm
@@ -93,7 +93,7 @@ __END__
 =head1 DESCRIPTION
 
 Container for Cypher result values. Records are returned from Cypher
-statement execution, contained within a Result. A record is
+query execution, contained within a Result. A record is
 a form of ordered map and, as such, contained values can be accessed
 by either positional index or textual key.
 

--- a/lib/Neo4j/Driver/Result.pm
+++ b/lib/Neo4j/Driver/Result.pm
@@ -61,7 +61,7 @@ sub single {
 	
 	croak 'There is not exactly one result record' if $self->size != 1;
 	my ($record) = $self->list;
-	$record->{_summary} = $self->summary if $self->{result}->{stats};
+	$record->{_summary} = $self->_summary if $self->{result}->{stats};
 	return $record;
 }
 
@@ -154,11 +154,18 @@ sub consume {
 	my ($self) = @_;
 	
 	1 while $self->fetch;  # Exhaust the result stream
-	return $self->summary;
+	return $self->_summary;
 }
 
 
 sub summary {
+	# uncoverable pod (see consume)
+	warnings::warnif deprecated => "summary() in Neo4j::Driver::Result is deprecated; use consume() instead";
+	&_summary;
+}
+
+
+sub _summary {
 	my ($self) = @_;
 	
 	$self->_fill_buffer;
@@ -256,6 +263,11 @@ result stream, discarding any remaining records. If you want to
 access records I<after> retrieving the summary, you should use
 C<list()> before C<consume()> to buffer all records into memory.
 
+Before driver S<version 0.44>, the summary was retrieved with
+the C<summary()> method, which didn't exhaust the result.
+That method has since been deprecated, matching a corresponding
+change in S<Neo4j 4.0>.
+
 =head2 fetch
 
  while ($record = $result->fetch) {
@@ -330,23 +342,6 @@ Return the count of records that calling C<list()> would yield.
 
 Calling this method exhausts the result stream and buffers all records
 for use by C<list()>.
-
-=head2 summary
-
- $result_summary = $result->summary;
-
-Return a L<Neo4j::Driver::ResultSummary> object. Calling this method
-detaches the result stream, but does I<not> exhaust it.
-
-This method is discouraged. It may be deprecated and removed in
-a future version. Please use C<consume()> instead.
-
-As a special case, L<Record|Neo4j::Driver::Record>s returned by the
-C<single> method also have a C<summary> method that works the same
-way.
-
- $record = $transaction->run('...')->single;
- $result_summary = $record->summary;
 
 =head1 SEE ALSO
 

--- a/lib/Neo4j/Driver/Result.pm
+++ b/lib/Neo4j/Driver/Result.pm
@@ -4,7 +4,7 @@ use warnings;
 use utf8;
 
 package Neo4j::Driver::Result;
-# ABSTRACT: Result of running a Cypher statement (a stream of records)
+# ABSTRACT: Result of running a Cypher query (a stream of records)
 
 
 use Carp qw(croak);
@@ -215,7 +215,7 @@ __END__
 
 =head1 DESCRIPTION
 
-The result of running a Cypher statement, conceptually a stream of
+The result of running a Cypher query, conceptually a stream of
 records. The result stream can be navigated through using C<fetch()>
 to consume records one at a time, or be consumed in its entirety
 using C<list()> to get an array of all records.
@@ -226,7 +226,7 @@ buffered locally in the driver. Once I<all> data on the result stream
 has been retrieved from the server and buffered locally, the stream
 becomes B<detached.>
 
-Result streams are valid until the next statement
+Result streams are valid until the next query
 is run on the same session or (if the result was retrieved within
 an explicit transaction) until the transaction is closed, whichever
 comes first. When a result stream has become invalid I<before> it
@@ -240,8 +240,6 @@ This behaviour is subject to change in future versions and
 shouldn't be relied upon.
 
 To obtain a query result, call L<Neo4j::Driver::Transaction/"run">.
-
-Until version 0.18, this module was named C<StatementResult>.
 
 =head1 METHODS
 

--- a/lib/Neo4j/Driver/ResultSummary.pm
+++ b/lib/Neo4j/Driver/ResultSummary.pm
@@ -4,7 +4,7 @@ use warnings;
 use utf8;
 
 package Neo4j::Driver::ResultSummary;
-# ABSTRACT: Details about the result of running a statement
+# ABSTRACT: Details about the result of running a query
 
 
 use Carp qw(croak);
@@ -60,6 +60,13 @@ sub plan {
 
 
 sub statement {
+	# uncoverable pod (see query)
+	warnings::warnif deprecated => "statement() in Neo4j::Driver::ResultSummary is deprecated; use query() instead";
+	&query;
+}
+
+
+sub query {
 	my ($self) = @_;
 	
 	return {
@@ -101,7 +108,7 @@ __END__
 
 =head1 DESCRIPTION
 
-The result summary of running a statement. The result summary can be
+The result summary of running a query. The result summary can be
 used to investigate details about the result, like the Neo4j server
 version, how many and which kinds of updates have been executed, and
 query plan information if available.
@@ -117,7 +124,7 @@ L<Neo4j::Driver::ResultSummary> implements the following methods.
  $summary_counters = $summary->counters;
 
 Returns the L<SummaryCounters|Neo4j::Driver::SummaryCounters> with
-statistics counts for operations the statement triggered.
+statistics counts for operations the query triggered.
 
 =head2 notifications
 
@@ -126,10 +133,10 @@ statistics counts for operations the statement triggered.
  print Dumper @notifications;
 
 A list of notifications that might arise when executing the
-statement. Notifications can be warnings about problematic statements
+query. Notifications can be warnings about problematic queries
 or other valuable information that can be presented in a client.
 Unlike failures or errors, notifications do not affect the execution
-of a statement.
+of a query.
 In scalar context, return the number of notifications.
 
 This driver only supports notifications over HTTP.
@@ -139,10 +146,21 @@ This driver only supports notifications over HTTP.
  use Data::Dumper;
  print Dumper $summary->plan;
 
-This describes how the database will execute your statement.
-Available if this is the summary of a Cypher C<EXPLAIN> statement.
+This describes how the database will execute your query.
+Available if this is the summary of a Cypher C<EXPLAIN> query.
 
 This driver only supports execution plans over HTTP.
+
+=head2 query
+
+ $query  = $summary->query->{text};
+ $params = $summary->query->{parameters};
+
+The executed query and query parameters this summary is for.
+
+Before driver S<version 1.00>, the query was retrieved with the
+C<statement()> method. That method has since been deprecated,
+matching a corresponding change in S<Neo4j 4.0>.
 
 =head2 server
 
@@ -151,13 +169,6 @@ This driver only supports execution plans over HTTP.
 
 The L<ServerInfo|Neo4j::Driver::ServerInfo>, consisting of
 the host, port, protocol and Neo4j version.
-
-=head2 statement
-
- $query  = $summary->statement->{text};
- $params = $summary->statement->{parameters};
-
-The statement and parameters this summary is for.
 
 =head1 SEE ALSO
 

--- a/lib/Neo4j/Driver/ServerInfo.pm
+++ b/lib/Neo4j/Driver/ServerInfo.pm
@@ -25,11 +25,17 @@ sub new {
 
 sub address  { shift->{uri} }
 sub agent    { shift->{version} }
-sub version  { shift->{version} }
 
 
 sub protocol_version {
 	shift->{protocol}
+}
+
+
+sub version {
+	# uncoverable pod (see agent)
+	warnings::warnif deprecated => "version() in Neo4j::Driver::ServerInfo is deprecated; use agent() instead";
+	&agent;
 }
 
 
@@ -90,6 +96,10 @@ of an URL authority string (for example: C<localhost:7474>).
 Returns the product name and version number. Takes the form of
 a server agent string (for example: C<Neo4j/3.5.17>).
 
+Before driver S<version 0.26>, the agent string was retrieved with
+the C<version()> method. That method has since been deprecated,
+matching a corresponding change in S<Neo4j 4.3>.
+
 =head2 protocol_version
 
  $bolt_version = $session->server->protocol_version;
@@ -104,15 +114,6 @@ returns an undefined value.
 If the Bolt protocol is used, but the version number is unknown,
 an empty string is returned. This situation shouldn't occur unless
 you use L<Neo4j::Bolt> S<version 0.20> or older.
-
-=head2 version
-
- $agent_string = $session->server->version;
-
-Alias for L<C<agent()>|/"agent">.
-
-Use of C<version()> is discouraged since version 0.26.
-This method may be deprecated and removed in future.
 
 =head1 SEE ALSO
 

--- a/lib/Neo4j/Driver/Session.pm
+++ b/lib/Neo4j/Driver/Session.pm
@@ -315,7 +315,7 @@ which is always safe to do.
 
  $result = $session->run('...');
 
-Run and commit a statement using an auto-commit transaction and return
+Run and commit a query using an auto-commit transaction and return
 the L<Result|Neo4j::Driver::Result>.
 
 This method is semantically exactly equivalent to the following code,

--- a/lib/Neo4j/Driver/SummaryCounters.pm
+++ b/lib/Neo4j/Driver/SummaryCounters.pm
@@ -4,7 +4,7 @@ use warnings;
 use utf8;
 
 package Neo4j::Driver::SummaryCounters;
-# ABSTRACT: Statement statistics
+# ABSTRACT: Query statistics
 
 
 sub new {
@@ -71,7 +71,7 @@ __END__
 
 =head1 DESCRIPTION
 
-Contains counters for various operations that a statement triggered.
+Contains counters for various operations that a query triggered.
 
 To obtain summary counters, call
 L<Neo4j::Driver::ResultSummary/"counters">.

--- a/lib/Neo4j/Driver/Transaction.pm
+++ b/lib/Neo4j/Driver/Transaction.pm
@@ -311,11 +311,11 @@ Logical container for an atomic unit of work that is either committed
 in its entirety or is rolled back on failure. A driver Transaction
 object corresponds to a server transaction.
 
-Statements may be run lazily. Most of the time, you will not notice
-this, because the driver automatically waits for statements to
+Queries may be run lazily. Most of the time, you will not notice
+this, because the driver automatically waits for queries to
 complete at specific points to fulfill its contracts. If you require
-execution of a statement to have completed (S<e. g.> to check for
-statement errors), you need to call any method in the
+execution of a query to have completed (S<e. g.> to check for
+query errors), you need to call any method in the
 L<Result|Neo4j::Driver::Result>, such as C<has_next()>.
 
 Neo4j drivers allow the creation of different kinds of transactions.
@@ -359,9 +359,9 @@ used.
  $result = $transaction->run($query);
  $result = $transaction->run($query, \%params);
 
-Run a statement and return the L<Result|Neo4j::Driver::Result>.
+Run a query and return the L<Result|Neo4j::Driver::Result>.
 This method takes an optional set of parameters that will be injected
-into the Cypher statement by Neo4j. Using parameters is highly
+into the Cypher query by Neo4j. Using parameters is highly
 encouraged: It helps avoid dangerous Cypher injection attacks and
 improves database performance as Neo4j can re-use query plans more
 often.
@@ -414,7 +414,7 @@ This driver always reports all errors using C<die()>. Error messages
 received from the Neo4j server are passed on as-is.
 See L<Neo4j::Driver::Plugin/"error"> for accessing error details.
 
-Statement errors occur when the statement is executed on the server.
+Query errors can occur when the query is executed on the server.
 This may not necessarily have happened by the time C<run()> returns.
 If you use L<C<try>/C<catch>|Feature::Compat::Try> to handle errors,
 make sure you actually I<use> the L<Result|Neo4j::Driver::Result>

--- a/t/bolt.t
+++ b/t/bolt.t
@@ -96,7 +96,7 @@ sub new_session {
 	my $d = Neo4j::Driver->new('bolt:');
 	$d->{config}->{net_module} = shift;
 	$d->basic_auth(username => 'password');
-	$d->{config}->{tls} = shift if scalar @_;
+	$d->{config}->{encrypted} = shift if scalar @_;
 	$d->{config}->{auth} = shift if scalar @_;
 	return ( $d, $d->session(database => 'dummy') );
 }

--- a/t/deprecated.t
+++ b/t/deprecated.t
@@ -118,7 +118,7 @@ subtest 'die_on_error = 0' => sub {
 	is $Neo4j_Test::Plugin::NoDieOnError::error->as_string, 'bar', 'error text';
 	
 	# Surviving errors yields results with no summary
-	ok ! eval { $r->summary->server }, 'error missing summary';
+	ok ! eval { $r->consume->server }, 'error missing summary';
 };
 
 

--- a/t/net-lwp.t
+++ b/t/net-lwp.t
@@ -212,13 +212,13 @@ subtest 'tls' => sub {
 	plan tests => 8;
 	my $config;
 	lives_ok {
-		$config = { uri => URI->new('https://e.net.test/'), tls => 1 };
+		$config = { uri => URI->new('https://e.net.test/'), encrypted => 1 };
 		$driver = Neo4j_Test::DriverConfig->new($config);
 		$m = Neo4j::Driver::Net::HTTP::LWP->new($driver);
 	} 'encrypted https';
 	lives_and { like $m->uri(), qr|^https://e|i } 'encrypted https uri';
 	lives_ok {
-		$config = { uri => URI->new('https://d.net.test/'), tls => undef };
+		$config = { uri => URI->new('https://d.net.test/'), encrypted => undef };
 		$driver = Neo4j_Test::DriverConfig->new($config);
 		$m = Neo4j::Driver::Net::HTTP::LWP->new($driver);
 	} 'https';
@@ -227,7 +227,7 @@ subtest 'tls' => sub {
 	SKIP: {
 		skip "(Mozilla::CA unavailable)", 4 unless $ca_file;
 		lives_ok {
-			$config = { uri => URI->new('https://c.net.test/'), tls_ca => $ca_file };
+			$config = { uri => URI->new('https://c.net.test/'), trust_ca => $ca_file };
 			$driver = Neo4j_Test::DriverConfig->new($config);
 			$m = Neo4j::Driver::Net::HTTP::LWP->new($driver);
 		} 'https ca_file lives';
@@ -242,14 +242,14 @@ subtest 'tls config errors' => sub {
 	plan tests => 2;
 	my $config;
 	throws_ok {
-		$config = { uri => $base, tls => 1 };
+		$config = { uri => $base, encrypted => 1 };
 		$driver = Neo4j_Test::DriverConfig->new($config);
 		Neo4j::Driver::Net::HTTP::LWP->new($driver);
 	} qr/\bHTTP does not support encrypted communication\b/i, 'no encrypted http';
 	SKIP: {
 		skip "(LWP::Protocol::https unavailable)", 1 unless eval 'require LWP::Protocol::https; 1';
 		throws_ok {
-			$config = { uri => URI->new('https://net.test/'), tls => 0 };
+			$config = { uri => URI->new('https://net.test/'), encrypted => 0 };
 			$driver = Neo4j_Test::DriverConfig->new($config);
 			Neo4j::Driver::Net::HTTP::LWP->new($driver);
 		} qr/\bHTTPS does not support unencrypted communication\b/i, 'no unencrypted https';
@@ -265,9 +265,7 @@ package Neo4j_Test::DriverConfig;
 sub config {
 	my ($driver, $option) = @_;
 	my %aliases = (
-		encrypted => 'tls',
 		timeout => 'http_timeout',
-		trust_ca => 'tls_ca',
 	);
 	return $driver->{$aliases{$option}} if $aliases{$option};
 	return $driver->{$option};

--- a/t/session.t
+++ b/t/session.t
@@ -42,7 +42,7 @@ subtest 'database selection (HTTP)' => sub {
 	my ($version, $db);
 	# no database option (or undefined)
 	lives_ok { $s = 0; $s = $driver->session( database => undef ); } 'default lives';
-	($version) = $s->server->version =~ m(Neo4j/([0-9]+)\.)i;
+	($version) = $s->server->agent =~ m(Neo4j/([0-9]+)\.)i;
 	ok defined $version, 'version number';
 	if ($version >= 4) {
 		# this test assumes that the default database is always named neo4j

--- a/t/transaction.t
+++ b/t/transaction.t
@@ -196,7 +196,7 @@ CLEANUP: {
 MATCH (n) WHERE id(n) = {node_id} DELETE n
 END
 		lives_ok { $r = $t->run( $q, node_id => 0 + $undo_id ) } "undo commit [id $undo_id]";
-		lives_and { ok $r->summary->counters->nodes_deleted } 'undo commit verified';
+		lives_and { ok $r->consume->counters->nodes_deleted } 'undo commit verified';
 		lives_ok { $t->commit } 'undo commit execute';
 	}
 }

--- a/t/types.t
+++ b/t/types.t
@@ -59,7 +59,7 @@ END
 };
 
 
-eval { $ver = '??'; $ver = $s->server->version; };
+eval { $ver = '??'; $ver = $s->server->agent; };
 
 
 subtest 'Property types: spatial type semantics' => sub {

--- a/xt/author/cpan-distros.t
+++ b/xt/author/cpan-distros.t
@@ -25,7 +25,7 @@ use if $no_warnings = $ENV{AUTHOR_TESTING} ? 1 : 0, 'Test::Warnings';
 use Neo4j_Test;
 
 my $driver = $ENV{NO_NETWORK_TESTING} ? 0 : Neo4j_Test->driver();
-my $neo4j_ver = $driver && $driver->session->server->version;
+my $neo4j_ver = $driver && $driver->session->server->agent;
 plan skip_all => "no connection to Neo4j server" unless $driver && ! $Neo4j_Test::sim;
 plan skip_all => "Neo4j server version too old" if $neo4j_ver =~ m{^Neo4j/[12]\.};
 

--- a/xt/author/internals.t
+++ b/xt/author/internals.t
@@ -81,9 +81,10 @@ subtest 'disable HTTP summary counters' => sub {
 	my $tx = $driver->session->begin_transaction;
 	$tx->{return_stats} = 0;
 	dies_ok {
-		$tx->run('RETURN "no stats 0"')->summary->counters->labels_added;
+		$tx->run('RETURN "no stats 0"')->consume->counters->labels_added;
 	} 'no stats requested - summary';
 	dies_ok {
+		no warnings 'deprecated';
 		$tx->run('RETURN "no stats 1"')->single->summary->counters->labels_added;
 	} 'no stats requested - single summary';
 	lives_ok {
@@ -99,7 +100,7 @@ subtest 'summary: plan/notification internals' => sub {
 	$q = <<END;
 EXPLAIN MATCH (n), (m) RETURN n, m
 END
-	lives_ok { $r = $s->run($q)->summary; } 'get summary with plan';
+	lives_ok { $r = $s->run($q)->consume; } 'get summary with plan';
 	my ($plan, @notifications);
 	lives_ok { $plan = $r->plan;  1; } 'get plan';
 	SKIP: {
@@ -120,8 +121,8 @@ subtest 'summary: repeated invocation' => sub {
 	# to the exact same object.
 	plan tests => 3;
 	lives_ok { $r = $s->run('RETURN 42') } 'get result';
-	lives_and { is $r->summary, $r->summary } 'summary identical';
-	lives_and { is $r->summary->counters, $r->summary->counters } 'counters identical';
+	lives_and { is $r->consume, $r->consume } 'summary identical';
+	lives_and { is $r->consume->counters, $r->consume->counters } 'counters identical';
 };
 
 


### PR DESCRIPTION
Neo4j and the official drivers made several changes to their terminology over the years. This change deprecates the old names of affected methods and config options.

* [Neo4j::Driver::Config](https://metacpan.org/dist/Neo4j-Driver/view/lib/Neo4j/Driver/Config.pod):  `tls` → `encrypted`
* [Neo4j::Driver::Config](https://metacpan.org/dist/Neo4j-Driver/view/lib/Neo4j/Driver/Config.pod):  `tls_ca` → `trust_ca`
* [Neo4j::Driver::Result](https://metacpan.org/pod/Neo4j::Driver::Result):  `summary()` → `consume()`
* [Neo4j::Driver::ResultSummary](https://metacpan.org/pod/Neo4j::Driver::ResultSummary):  `statement()` → `query()`
* [Neo4j::Driver::ServerInfo](https://metacpan.org/pod/Neo4j::Driver::ServerInfo):  `version()` → `agent()`

My intention is to generally keep the Perl driver’s interface stable going forward, even in the face of changes in Neo4j. However, for these particular methods and config options, removing them seems justified. The driver’s major version number change is a good opportunity to declare my intention to do so *eventually.*

[^1]: My reference.