### PR TITLE
Pass through Neo4j::Bolt values unchanged, significantly reducing overhead

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Neo4j::Driver
 
+1.0151  2024-12-01  (TRIAL RELEASE)
+
+ - Pass through Neo4j::Bolt values unchanged, significantly reducing overhead.
+
 1.01  2024-11-28  (TRIAL RELEASE)
 
  - Using Jolt byte array objects in string context now yields the class name.

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2016-2024
 
-version = 1.01
+version = 1.0151
 release_status = unstable
 
 [Meta::Contributors]

--- a/lib/Neo4j/Driver/Net/Bolt.pm
+++ b/lib/Neo4j/Driver/Net/Bolt.pm
@@ -56,7 +56,6 @@ sub new {
 		uri => $uri,
 		result_module => $net_module->can('result_handlers') ? ($net_module->result_handlers)[0] : $RESULT_MODULE,
 		server_info => $driver->{server_info},
-		cypher_types => $driver->{config}->{cypher_types},
 		active_tx => 0,
 	}, $class;
 }
@@ -198,7 +197,6 @@ sub _run {
 			bolt_stream => $stream,
 			bolt_connection => $self->{connection},
 			query => $query,
-			cypher_types => $self->{cypher_types},
 			server_info => $self->{server_info},
 			error_handler => $tx->{error_handler},
 		});

--- a/t/bolt.t
+++ b/t/bolt.t
@@ -85,7 +85,10 @@ sub get_failure_details {}
 sub reset_cxn { $_[0]->{$_} = $_[0]->{"reset_$_"} for qw( errnum errmsg ); }
 sub _bolt_error { &Neo4j::Driver::Net::Bolt::_bolt_error }
 
-package Neo4j::Bolt::Bytes { use parent 'Neo4j::Types::ByteArray' }
+package Neo4j::Bolt::Bytes        { use parent 'Neo4j::Types::ByteArray' }
+package Neo4j::Bolt::Node         { use parent 'Neo4j::Types::Node' }
+package Neo4j::Bolt::Path         { use parent 'Neo4j::Types::Path' }
+package Neo4j::Bolt::Relationship { use parent 'Neo4j::Types::Relationship' }
 
 package main;
 

--- a/t/deprecated.t
+++ b/t/deprecated.t
@@ -50,6 +50,7 @@ lives_ok { $r = 0; $r = $transaction->run($q)->single; } 'run query (structural 
 
 subtest 'direct node/rel/path access' => sub {
 	plan skip_all => '(query failed)' if ! $r;
+	plan skip_all => 'Neo4j::Bolt is designed for direct access' if $Neo4j_Test::bolt;
 	plan tests => 6;
 	ok my $n = $r->get('n4'), 'get node';
 	dies_ok { $n->{answer} = 42 } 'set node prop';

--- a/t/json-utf8.t
+++ b/t/json-utf8.t
@@ -94,7 +94,7 @@ subtest 'read full property list' => sub {
 	lives_ok {
 		$node = $r->list->[0]->get(0);
 	} 'get node';
-	is ref $node, 'Neo4j::Driver::Type::Node', '$node is blessed node';
+	isa_ok $node, 'Neo4j::Types::Node', '$node is blessed node';
 	foreach my $key (@keys) {
 		is to_hex $node->get($key), to_hex $props{$key}, "prop: $key";
 	}

--- a/t/types.t
+++ b/t/types.t
@@ -139,8 +139,8 @@ subtest 'Structural types: node meta data and props' => sub {
 	ok my $n1 = $r0->get('n1'), 'get node 1';
 	ok my $n2 = $r0->get('n2'), 'get node 2';
 	ok defined($id = $r0->get('id(n1)')), 'get node 1 id';
-	is ref $n1, 'Neo4j::Driver::Type::Node', 'node 1 blessed';
-	is ref $n2, 'Neo4j::Driver::Type::Node', 'node 2 blessed';
+	isa_ok $n1, 'Neo4j::Types::Node', 'node 1 blessed';
+	isa_ok $n2, 'Neo4j::Types::Node', 'node 2 blessed';
 	{ no warnings 'deprecated';  # id()
 	is $n1->id, $id, 'node 1 id matches';
 	isnt $n2->id, $n1->id, 'node 2 id distinct';
@@ -162,8 +162,8 @@ subtest 'Structural types: relation meta data and props' => sub {
 	ok my $n2 = $r0->get('n2'), 'get node 2';
 	ok my $e1 = $r0->get('e1'), 'get rel 1';
 	ok my $e2 = $r0->get('e2'), 'get rel 2';
-	is ref $e1, 'Neo4j::Driver::Type::Relationship', 'rel 1 blessed';
-	is ref $e2, 'Neo4j::Driver::Type::Relationship', 'rel 2 blessed';
+	isa_ok $e1, 'Neo4j::Types::Relationship', 'rel 1 blessed';
+	isa_ok $e2, 'Neo4j::Types::Relationship', 'rel 2 blessed';
 	{ no warnings 'deprecated';  # id()
 	is $e1->id, $r0->get('id(e1)'), 'rel 1 id matches';
 	isnt $e2->id, $e1->id, 'rel 2 id distinct';
@@ -180,17 +180,17 @@ subtest 'Structural types: path accessors' => sub {
 	plan skip_all => '(query failed)' if ! $r0;
 	plan tests => 2 + (6 + 5 + 4);
 	ok my $p = $r0->get('p1'), 'get path';
-	is ref $p, 'Neo4j::Driver::Type::Path', 'path blessed';
+	isa_ok $p, 'Neo4j::Types::Path', 'path blessed';
 	SKIP: {
-		skip '(path not blessed)', (6 + 5 + 4) unless ref $p eq 'Neo4j::Driver::Type::Path';
+		skip '(path not blessed)', (6 + 5 + 4) if ref $p !~ m/^Neo4j::/;
 		ok my @nodes = $p->nodes, 'get nodes';
 		ok my @rels = $p->relationships, 'get rels';
 		ok my @all = $p->elements, 'get elements';
 		is scalar @nodes, 3, 'node count';
 		is scalar @rels, 2, 'rels count';
 		is scalar @all, 5, 'element count';
-		is ref $_, 'Neo4j::Driver::Type::Node', 'node blessed' for @nodes;
-		is ref $_, 'Neo4j::Driver::Type::Relationship', 'rel blessed' for @rels;
+		isa_ok $_, 'Neo4j::Types::Node', 'node blessed' for @nodes;
+		isa_ok $_, 'Neo4j::Types::Relationship', 'rel blessed' for @rels;
 		{ no warnings 'deprecated';  # id()
 		is $nodes[0]->id, $nodes[2]->id, 'path circular';
 		isnt $nodes[0]->id, $nodes[1]->id, 'nodes distinct';
@@ -227,14 +227,14 @@ END
 	is ref $l, 'ARRAY', 'list =array';
 	is scalar @$l, 4, 'list size';
 	is $l->[0], 17, 'number in list';
-	is ref $l->[1], 'Neo4j::Driver::Type::Node', 'blessed node in list';
+	isa_ok $l->[1], 'Neo4j::Types::Node', 'blessed node in list';
 	is $l->[2], undef, 'null in list';
-	is ref $l->[3], 'Neo4j::Driver::Type::Path', 'blessed path in list';
+	isa_ok $l->[3], 'Neo4j::Types::Path', 'blessed path in list';
 	ok my $m = $r->get(1), 'get map';
 	is ref $m, 'HASH', 'map =hash';
 	is scalar keys %$m, 3, 'map size';
 	is $m->{first}, undef, 'null in map';
-	is ref $m->{second}, 'Neo4j::Driver::Type::Relationship', 'blessed rel in map';
+	isa_ok $m->{second}, 'Neo4j::Types::Relationship', 'blessed rel in map';
 	is $m->{third}, 23, 'number in map';
 	ok $l = $r->get(2), 'get empty list';
 	is ref $l, 'ARRAY', 'empty list =array';
@@ -261,15 +261,15 @@ END
 	lives_ok { $a1 = $r->get(0)->[0]->{node}; } 'list: get node "a"';
 	lives_ok { $b1 = $r->get(0)->[2]; } 'list: get node "b"';
 	lives_ok { $p1 = $r->get(0)->[1]->{path}; } 'list: get path "p"';
-	is ref $a1, 'Neo4j::Driver::Type::Node', 'list: blessed node "a"';
-	is ref $b1, 'Neo4j::Driver::Type::Node', 'list: blessed node "b"';
-	is ref $p1, 'Neo4j::Driver::Type::Path', 'list: blessed path "p"';
+	isa_ok $a1, 'Neo4j::Types::Node', 'list: blessed node "a"';
+	isa_ok $b1, 'Neo4j::Types::Node', 'list: blessed node "b"';
+	isa_ok $p1, 'Neo4j::Types::Path', 'list: blessed path "p"';
 	lives_ok { $a2 = $r->get(1)->{list}->[1]; } 'map: get node "a"';
 	lives_ok { $b2 = $r->get(1)->{node}; } 'map: get node "b"';
 	lives_ok { $p2 = $r->get(1)->{list}->[0]; } 'map: get node "p"';
-	is ref $a2, 'Neo4j::Driver::Type::Node', 'map: blessed node "a"';
-	is ref $b2, 'Neo4j::Driver::Type::Node', 'map: blessed node "b"';
-	is ref $p2, 'Neo4j::Driver::Type::Path', 'map: blessed path "p"';
+	isa_ok $a2, 'Neo4j::Types::Node', 'map: blessed node "a"';
+	isa_ok $b2, 'Neo4j::Types::Node', 'map: blessed node "b"';
+	isa_ok $p2, 'Neo4j::Types::Path', 'map: blessed path "p"';
 	{ no warnings 'deprecated';  # id()
 	lives_and { is $a1->id, $a2->id } 'node "a": id match';
 	lives_and { is $b1->id, $b2->id } 'node "b": id match';


### PR DESCRIPTION
The minimum supported version of [Neo4j::Bolt](https://metacpan.org/dist/Neo4j-Bolt) is now 0.4201, which is the first version to require [Neo4j::Types](https://metacpan.org/dist/Neo4j-Types). This means that converting Neo4j::Bolt values to Neo4j::Driver::Type values by traversing the tree of result values (“deep bless”) is no longer necessary.

As a result, receiving complex query results (e. g. with many columns, lists, maps, or properties) over Bolt is about twice as fast as before. The overhead of Neo4j::Driver is eliminated almost entirely for such queries.

The performance of Bolt with Neo4j::Driver continues to be limited by the general handling of queries and results, which is unaffected by this change. Very simple queries (e. g. having just a single scalar column) may still take up to twice as long as they would take if ran directly with [Neo4j::Bolt](https://metacpan.org/dist/Neo4j-Bolt). But such simple queries are typically very fast anyway, so this speed difference may not be too important for many applications.