### PR TITLE
Refactor structural type packages to match Jolt

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,9 @@
 Revision history for Neo4j::Driver
 
-1.0151  2024-12-01  (TRIAL RELEASE)
+1.0152  2024-12-02  (TRIAL RELEASE)
 
  - Pass through Neo4j::Bolt values unchanged, significantly reducing overhead.
+ - Optimise parsing of Jolt result values, improving performance.
 
 1.01  2024-11-28  (TRIAL RELEASE)
 

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2016-2024
 
-version = 1.0151
+version = 1.0152
 release_status = unstable
 
 [Meta::Contributors]

--- a/lib/Neo4j/Driver.pm
+++ b/lib/Neo4j/Driver.pm
@@ -12,14 +12,6 @@ use URI 1.25;
 use Neo4j::Driver::Events;
 use Neo4j::Driver::Session;
 
-use Neo4j::Driver::Type::Bytes;
-use Neo4j::Driver::Type::DateTime;
-use Neo4j::Driver::Type::Duration;
-use Neo4j::Driver::Type::Node;
-use Neo4j::Driver::Type::Relationship;
-use Neo4j::Driver::Type::Path;
-use Neo4j::Driver::Type::Point;
-
 
 my %NEO4J_DEFAULT_PORT = (
 	bolt => 7687,
@@ -40,21 +32,11 @@ my %OPTIONS = (
 	uri => 'uri',
 );
 
-my %DEFAULTS = (
-	cypher_types => {
-		node => 'Neo4j::Driver::Type::Node',
-		relationship => 'Neo4j::Driver::Type::Relationship',
-		path => 'Neo4j::Driver::Type::Path',
-		point => 'Neo4j::Driver::Type::Point',
-		temporal => 'Neo4j::Driver::Type::Temporal',
-	},
-);
-
 
 sub new {
 	my ($class, $config, @extra) = @_;
 	
-	my $self = bless { config => { %DEFAULTS } }, $class;
+	my $self = bless {}, $class;
 	$self->{events} = Neo4j::Driver::Events->new;
 	
 	croak __PACKAGE__ . "->new() with multiple arguments unsupported" if @extra;

--- a/lib/Neo4j/Driver/Net/HTTP.pm
+++ b/lib/Neo4j/Driver/Net/HTTP.pm
@@ -42,7 +42,6 @@ sub new {
 	
 	my $self = bless {
 		events => $driver->{events},
-		cypher_types => $driver->{config}->{cypher_types},
 		server_info => $driver->{server_info},
 		http_agent => $http_adapter,
 		want_jolt => $driver->{config}->{jolt},
@@ -183,7 +182,6 @@ sub _request {
 		http_method => $method,
 		http_path => $tx_endpoint,
 		http_header => $header,
-		cypher_types => $self->{cypher_types},
 		server_info => $self->{server_info},
 		queries => $json ? $json->{statements} : [],
 	});

--- a/lib/Neo4j/Driver/Result/Jolt.pm
+++ b/lib/Neo4j/Driver/Result/Jolt.pm
@@ -226,7 +226,7 @@ sub _deep_bless {
 		return $data ? $TRUE : $FALSE;
 	}
 	if (ref $data eq 'ARRAY') {  # List (sparse)
-		$data->[$_] = $self->_deep_bless($data->[$_]) for 0 .. $#{$data};
+		$_ = $self->_deep_bless($_) for @$data;
 		return $data;
 	}
 	if (ref $data eq '') {  # Null or Integer (sparse) or String (sparse)
@@ -254,14 +254,13 @@ sub _deep_bless {
 	}
 	if ($sigil eq '[]') {  # List (strict)
 		die "Assertion failed: unexpected list type: " . ref $value unless ref $value eq 'ARRAY';
-		$value->[$_] = $self->_deep_bless($value->[$_]) for 0 .. $#{$value};
+		$_ = $self->_deep_bless($_) for @$value;
 		return $value;
 	}
 	if ($sigil eq '{}') {  # Map
 		die "Assertion failed: unexpected map type: " . ref $value unless ref $value eq 'HASH';
-		delete $data->{'{}'};
-		$data->{$_} = $self->_deep_bless($value->{$_}) for keys %$value;
-		return $data;
+		$_ = $self->_deep_bless($_) for values %$value;
+		return $value;
 	}
 	if ($sigil eq '()') {  # Node
 		die "Assertion failed: unexpected node type: " . ref $value unless ref $value eq 'ARRAY';

--- a/lib/Neo4j/Driver/Type/DateTime.pm
+++ b/lib/Neo4j/Driver/Type/DateTime.pm
@@ -14,10 +14,6 @@ use parent 'Neo4j::Types::DateTime';
 sub _parse {
 	my ($self) = @_;
 	
-	if ( ! exists $self->{T} ) {  # JSON format
-		$self->{T} = $self->{data};
-	}
-	
 	my ($days, $hours, $mins, $secs, $nanos, $tz) = $self->{T} =~ m/^(?:([-+]?[0-9]{4,}-[0-9]{2}-[0-9]{2}))?T?(?:([0-9]{2}):([0-9]{2}):([0-9]{2})(?:[,.]([0-9]+))?)?(.*)$/;
 	
 	if (defined $days) {

--- a/lib/Neo4j/Driver/Type/Duration.pm
+++ b/lib/Neo4j/Driver/Type/Duration.pm
@@ -14,10 +14,6 @@ use parent 'Neo4j::Types::Duration';
 sub _parse {
 	my ($self) = @_;
 	
-	if ( ! exists $self->{T} ) {  # JSON format
-		$self->{T} = $self->{data};
-	}
-	
 	my ($minus, $years, $months, $weeks, $days, $hours, $mins, $secs, $nanos) = $self->{T} =~ m/^(-)?P(?:([-0-9.]+)Y)?(?:([-0-9.]+)M)?(?:([-0-9.]+)W)?(?:([-0-9.]+)D)?(?:T(?:([-0-9.]+)H)?(?:([-0-9.]+)M)?(?:([-0-9]+)(?:[,.]([0-9]+))?S)?)?$/;
 	
 	my $sign = $minus ? -1 : 1;

--- a/lib/Neo4j/Driver/Type/Node.pm
+++ b/lib/Neo4j/Driver/Type/Node.pm
@@ -7,53 +7,45 @@ package Neo4j::Driver::Type::Node;
 
 # For documentation, see Neo4j::Driver::Types.
 
+# Jolt node: [ node_id, [node_labels], {properties} ]
+
 
 use parent 'Neo4j::Types::Node';
-use overload '%{}' => \&_hash, fallback => 1;
-
-use Carp qw(croak);
 
 
 sub get {
 	my ($self, $property) = @_;
 	
-	return $$self->{$property};
+	return $self->[2]->{$property};
 }
 
 
 sub labels {
 	my ($self) = @_;
 	
-	$$self->{_meta}->{labels} //= [];
-	return @{ $$self->{_meta}->{labels} };
+	return @{ $self->[1] };
 }
 
 
 sub properties {
 	my ($self) = @_;
 	
-	my $properties = { %$$self };
-	delete $properties->{_meta};
-	return $properties;
+	return { %{$self->[2]} };
 }
 
 
 sub element_id {
 	my ($self) = @_;
 	
-	return $$self->{_meta}->{element_id} if defined $$self->{_meta}->{element_id};
-	warnings::warnif 'Neo4j::Types', 'element_id unavailable';
-	return $$self->{_meta}->{id};
+	return $self->[0];
 }
 
 
 sub id {
 	my ($self) = @_;
 	
-	return $$self->{_meta}->{id} if defined $$self->{_meta}->{id};
-	
 	warnings::warnif deprecated => "Node->id() is deprecated since Neo4j 5; use element_id()";
-	my ($id) = $$self->{_meta}->{element_id} =~ m/^4:[^:]*:([0-9]+)/;
+	my ($id) = $self->[0] =~ m/^4:[^:]*:([0-9]+)/;
 	$id = 0 + $id if defined $id;
 	return $id;
 }
@@ -61,15 +53,11 @@ sub id {
 # numeric ID from the response entirely. Therefore we generate it
 # here using the algorithm from Neo4j's DefaultElementIdMapperV1;
 # the final part of the element ID is identical to the legacy ID
-# according to CypherFunctions in Neo4j 5.3. This may break with
-# future Neo4j versions.
-# https://github.com/neo4j/neo4j/blob/0c092b70cc/community/kernel/src/main/java/org/neo4j/kernel/api/DefaultElementIdMapperV1.java#L62-L68
-# https://github.com/neo4j/neo4j/blob/0c092b70cc/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherFunctions.java#L771-L802
-
-
-sub _hash {
-	croak 'Use properties() to access Neo4j node properties';
-}
+# according to CypherFunctions in Neo4j 5.0-5.25.
+# But this may break with future Neo4j versions.
+# https://github.com/neo4j/neo4j/blob/5.25/community/values/src/main/java/org/neo4j/values/DefaultElementIdMapperV1.java#L61-L67
+# https://github.com/neo4j/neo4j/blob/5.25/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/operations/CypherFunctions.java#L1024-L1062
+# https://community.neo4j.com/t/id-function-deprecated-how-to-replace-easily/62554/17
 
 
 1;

--- a/lib/Neo4j/Driver/Type/Path.pm
+++ b/lib/Neo4j/Driver/Type/Path.pm
@@ -9,16 +9,13 @@ package Neo4j::Driver::Type::Path;
 
 
 use parent 'Neo4j::Types::Path';
-use overload '@{}' => \&_array, fallback => 1;
-
-use Carp qw(croak);
 
 
 sub nodes {
 	my ($self) = @_;
 	
 	my $i = 0;
-	return grep { ++$i & 1 } @{$self->{path}};
+	return grep { ++$i & 1 } @{$self->{'..'}};
 }
 
 
@@ -26,19 +23,14 @@ sub relationships {
 	my ($self) = @_;
 	
 	my $i = 0;
-	return grep { $i++ & 1 } @{$self->{path}};
+	return grep { $i++ & 1 } @{$self->{'..'}};
 }
 
 
 sub elements {
 	my ($self) = @_;
 	
-	return @{$self->{path}};
-}
-
-
-sub _array {
-	croak 'Use elements() to access Neo4j path elements';
+	return @{$self->{'..'}};
 }
 
 

--- a/lib/Neo4j/Driver/Type/Point.pm
+++ b/lib/Neo4j/Driver/Type/Point.pm
@@ -14,11 +14,6 @@ use parent 'Neo4j::Types::Point';
 sub _parse {
 	my ($self) = @_;
 	
-	if ( ! exists $self->{'@'} ) {  # JSON format
-		$self->{srid} = $self->{crs}{srid};
-		return;
-	}
-	
 	my ($srid, $x, $y, $z) = $self->{'@'} =~ m/^SRID=([0-9]+);POINT(?: Z)? ?\(([-0-9.]+) ([-0-9.]+)(?: ([-0-9.]+))?\)$/;
 	
 	$self->{srid} = 0 + $srid;

--- a/lib/Neo4j/Driver/Type/Relationship.pm
+++ b/lib/Neo4j/Driver/Type/Relationship.pm
@@ -7,43 +7,38 @@ package Neo4j::Driver::Type::Relationship;
 
 # For documentation, see Neo4j::Driver::Types.
 
+# Jolt relationship: [ rel_id, start_node_id, rel_type, end_node_id, {properties} ]
+
 
 use parent 'Neo4j::Types::Relationship';
-use overload '%{}' => \&_hash, fallback => 1;
-
-use Carp ();
 
 
 sub get {
 	my ($self, $property) = @_;
 	
-	return $$self->{$property};
+	return $self->[4]->{$property};
 }
 
 
 sub type {
 	my ($self) = @_;
 	
-	return $$self->{_meta}->{type};
+	return $self->[2];
 }
 
 
 sub start_element_id {
 	my ($self) = @_;
 	
-	return $$self->{_meta}->{element_start} if defined $$self->{_meta}->{element_start};
-	warnings::warnif 'Neo4j::Types', 'start_element_id unavailable';
-	return $$self->{_meta}->{start};
+	return $self->[1];
 }
 
 
 sub start_id {
 	my ($self) = @_;
 	
-	return $$self->{_meta}->{start} if defined $$self->{_meta}->{start};
-	
 	warnings::warnif deprecated => "Relationship->start_id() is deprecated since Neo4j 5; use start_element_id()";
-	my ($id) = $$self->{_meta}->{element_start} =~ m/^4:[^:]*:([0-9]+)/;
+	my ($id) = $self->[1] =~ m/^4:[^:]*:([0-9]+)/;
 	$id = 0 + $id if defined $id;
 	return $id;
 }
@@ -52,19 +47,15 @@ sub start_id {
 sub end_element_id {
 	my ($self) = @_;
 	
-	return $$self->{_meta}->{element_end} if defined $$self->{_meta}->{element_end};
-	warnings::warnif 'Neo4j::Types', 'end_element_id unavailable';
-	return $$self->{_meta}->{end};
+	return $self->[3];
 }
 
 
 sub end_id {
 	my ($self) = @_;
 	
-	return $$self->{_meta}->{end} if defined $$self->{_meta}->{end};
-	
 	warnings::warnif deprecated => "Relationship->end_id() is deprecated since Neo4j 5; use end_element_id()";
-	my ($id) = $$self->{_meta}->{element_end} =~ m/^4:[^:]*:([0-9]+)/;
+	my ($id) = $self->[3] =~ m/^4:[^:]*:([0-9]+)/;
 	$id = 0 + $id if defined $id;
 	return $id;
 }
@@ -73,36 +64,26 @@ sub end_id {
 sub properties {
 	my ($self) = @_;
 	
-	my $properties = { %$$self };
-	delete $properties->{_meta};
-	return $properties;
+	return { %{$self->[4]} };
 }
 
 
 sub element_id {
 	my ($self) = @_;
 	
-	return $$self->{_meta}->{element_id} if defined $$self->{_meta}->{element_id};
-	warnings::warnif 'Neo4j::Types', 'element_id unavailable';
-	return $$self->{_meta}->{id};
+	return $self->[0];
 }
 
 
 sub id {
 	my ($self) = @_;
 	
-	return $$self->{_meta}->{id} if defined $$self->{_meta}->{id};
-	
 	warnings::warnif deprecated => "Relationship->id() is deprecated since Neo4j 5; use element_id()";
-	my ($id) = $$self->{_meta}->{element_id} =~ m/^5:[^:]*:([0-9]+)/;
+	my ($id) = $self->[0] =~ m/^5:[^:]*:([0-9]+)/;
 	$id = 0 + $id if defined $id;
 	return $id;
 }
-
-
-sub _hash {
-	Carp::croak 'Use properties() to access Neo4j relationship properties';
-}
+# see Node.pm for background on legacy ID parsing
 
 
 1;

--- a/lib/Neo4j/Driver/Type/V1/Node.pm
+++ b/lib/Neo4j/Driver/Type/V1/Node.pm
@@ -1,0 +1,29 @@
+use v5.12;
+use warnings;
+
+package Neo4j::Driver::Type::V1::Node;
+# ABSTRACT: Describes a node from a Neo4j graph, delivered via Jolt v1 or JSON
+
+
+# For documentation, see Neo4j::Driver::Types.
+
+
+use parent 'Neo4j::Driver::Type::Node';
+
+
+sub element_id {
+	my ($self) = @_;
+	
+	warnings::warnif 'Neo4j::Types', 'element_id unavailable';
+	return $self->[0];
+}
+
+
+sub id {
+	my ($self) = @_;
+	
+	return $self->[0];
+}
+
+
+1;

--- a/lib/Neo4j/Driver/Type/V1/Relationship.pm
+++ b/lib/Neo4j/Driver/Type/V1/Relationship.pm
@@ -1,0 +1,59 @@
+use v5.12;
+use warnings;
+
+package Neo4j::Driver::Type::V1::Relationship;
+# ABSTRACT: Describes a relationship from a Neo4j graph, delivered via Jolt v1 or JSON
+
+
+# For documentation, see Neo4j::Driver::Types.
+
+
+use parent 'Neo4j::Driver::Type::Relationship';
+
+
+sub element_id {
+	my ($self) = @_;
+	
+	warnings::warnif 'Neo4j::Types', 'element_id unavailable';
+	return $self->[0];
+}
+
+
+sub start_element_id {
+	my ($self) = @_;
+	
+	warnings::warnif 'Neo4j::Types', 'start_element_id unavailable';
+	return $self->[1];
+}
+
+
+sub end_element_id {
+	my ($self) = @_;
+	
+	warnings::warnif 'Neo4j::Types', 'end_element_id unavailable';
+	return $self->[3];
+}
+
+
+sub id {
+	my ($self) = @_;
+	
+	return $self->[0];
+}
+
+
+sub start_id {
+	my ($self) = @_;
+	
+	return $self->[1];
+}
+
+
+sub end_id {
+	my ($self) = @_;
+	
+	return $self->[3];
+}
+
+
+1;


### PR DESCRIPTION
With this change, Jolt values received from the server can be passed through to the user with only minimal changes in `_deep_bless()`.

As a result, receiving query results from Neo4j 4.2 and later over HTTP is faster than before (between 2 % and 20 % during my tests, with more complex results benefiting more).