### PR TITLE
Make properties() give a reference to the internal hash

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,9 +1,12 @@
 Revision history for Neo4j::Driver
 
-1.0152  2024-12-02  (TRIAL RELEASE)
+1.0153  2024-12-03  (TRIAL RELEASE)
 
  - Pass through Neo4j::Bolt values unchanged, significantly reducing overhead.
  - Optimise parsing of Jolt result values, improving performance.
+ - The properties() method of nodes and relationships now returns a reference
+   to the internal hash. This makes properties() the preferred way to retrieve
+   a single property.
 
 1.01  2024-11-28  (TRIAL RELEASE)
 

--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license = Artistic_2_0
 copyright_holder = Arne Johannessen
 copyright_year   = 2016-2024
 
-version = 1.0152
+version = 1.0153
 release_status = unstable
 
 [Meta::Contributors]

--- a/lib/Neo4j/Driver/Type/Node.pm
+++ b/lib/Neo4j/Driver/Type/Node.pm
@@ -30,7 +30,7 @@ sub labels {
 sub properties {
 	my ($self) = @_;
 	
-	return { %{$self->[2]} };
+	return $self->[2];
 }
 
 

--- a/lib/Neo4j/Driver/Type/Relationship.pm
+++ b/lib/Neo4j/Driver/Type/Relationship.pm
@@ -64,7 +64,7 @@ sub end_id {
 sub properties {
 	my ($self) = @_;
 	
-	return { %{$self->[4]} };
+	return $self->[4];
 }
 
 

--- a/lib/Neo4j/Driver/Types.pod
+++ b/lib/Neo4j/Driver/Types.pod
@@ -135,12 +135,15 @@ L<JSON::Types> or with simple unary coercions like this:
 
 =item Properties hash reference
 
-The C<properties()> method of node and relationship objects
-currently makes a new defensive copy of the properties hash
-each time it's called. S<Version 1.xx> of the driver will
-change this to give a reference to the internal hash instead,
-providing a significant performance increase. Until then,
-you might consider caching the hash ref locally.
+Since driver version 1.02, the C<properties()> method of node
+and relationship objects returns a reference to the internal
+hash. This makes C<properties()> the preferred way to retrieve a
+single property, as it's both faster and clearer than C<get()>.
+
+ $value = $node->properties->{key};
+ 
+ # Chaining get() is a potentially confusing anti-pattern
+ $value = $record->get('field')->get('key');  # avoid this!
 
 =back
 


### PR DESCRIPTION
This change stops `properties()` in Node and Relationship from making a new defensive copy every time it’s called. This is 10 % to 60 % faster in my tests; however, retrieving a property is very fast anyway, so this speed difference may not matter much.

More importantly, though, the resulting code is also clearer: From the name of the `get()` method, it isn’t obvious that it’s getting a property, and [Neo4j::Driver::Record](https://metacpan.org/pod/Neo4j::Driver::Record) actually has a `get()` method of its own that does something entirely different. In the past, this often lead to code like `->get->get`, which looks like a typo and is somewhat confusing.

Furthermore, `properties()` in Neo4j::Bolt packages has always done this, and this change makes values received over HTTP behave the same way.

The new behaviour is also the one recommended by [Neo4j::Types](https://metacpan.org/dist/Neo4j-Types) version 2 (https://github.com/johannessen/neo4j-types/issues/11).